### PR TITLE
feat: add pull-based auto-deploy

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -30,5 +30,18 @@ module.exports = {
         DASHBOARD_PORT: "3456",
       },
     },
+    {
+      name: "claude-autodeploy",
+      script: "./scripts/auto-deploy.sh",
+      cwd: "/home/edouard/claude-telegram-relay",
+      autorestart: true,
+      max_restarts: 5,
+      min_uptime: "10s",
+      restart_delay: 10000,
+      error_file: "/home/edouard/.claude-relay/logs/autodeploy-error.log",
+      out_file: "/home/edouard/.claude-relay/logs/autodeploy-out.log",
+      merge_logs: true,
+      log_date_format: "YYYY-MM-DD HH:mm:ss",
+    },
   ],
 };

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Auto-deploy: polls GitHub for new commits on master and deploys automatically
+# Runs as a PM2 service, checks every 60 seconds
+
+REPO_DIR="/home/edouard/claude-telegram-relay"
+LOG_PREFIX="[auto-deploy]"
+BRANCH="master"
+CHECK_INTERVAL=60
+
+cd "$REPO_DIR" || exit 1
+
+echo "$LOG_PREFIX Starting auto-deploy watcher on branch $BRANCH"
+
+while true; do
+    # Fetch latest from remote
+    git fetch origin "$BRANCH" --quiet 2>/dev/null
+
+    LOCAL=$(git rev-parse "$BRANCH" 2>/dev/null)
+    REMOTE=$(git rev-parse "origin/$BRANCH" 2>/dev/null)
+
+    if [ "$LOCAL" != "$REMOTE" ]; then
+        echo "$LOG_PREFIX New commits detected on $BRANCH"
+        echo "$LOG_PREFIX Local:  $LOCAL"
+        echo "$LOG_PREFIX Remote: $REMOTE"
+
+        # Pull changes
+        git checkout "$BRANCH" --quiet 2>/dev/null
+        git pull origin "$BRANCH" --quiet
+
+        if [ $? -eq 0 ]; then
+            echo "$LOG_PREFIX Pull successful"
+
+            # Install dependencies if package.json changed
+            if git diff --name-only "$LOCAL" "$REMOTE" | grep -q "package.json"; then
+                echo "$LOG_PREFIX package.json changed, running bun install"
+                bun install
+            fi
+
+            # Restart relay and dashboard
+            echo "$LOG_PREFIX Restarting PM2 services"
+            npx pm2 restart claude-relay --update-env 2>/dev/null
+            npx pm2 restart claude-dashboard --update-env 2>/dev/null
+
+            echo "$LOG_PREFIX Deploy complete: $(git log --oneline -1)"
+        else
+            echo "$LOG_PREFIX ERROR: git pull failed"
+        fi
+    fi
+
+    sleep "$CHECK_INTERVAL"
+done


### PR DESCRIPTION
## Summary
- Adds scripts/auto-deploy.sh: polls GitHub every 60s for new commits on master
- On new commits: git pull, bun install if needed, PM2 restart
- Adds claude-autodeploy service to ecosystem.config.cjs
- No SSH exposure or tunnel needed (works behind CGNAT/Bouygues)

## Test plan
- [ ] Verify auto-deploy service runs in PM2
- [ ] Merge this PR and confirm auto-deploy pulls the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)