### PR TITLE
feat: S06 - proactive notifications per topic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,17 @@ USER_NAME=Your Name
 # Your timezone (IANA format: America/New_York, Europe/Berlin, etc.)
 USER_TIMEZONE=UTC
 
+# --- OPTIONAL: Forum Topics ---
+
+# Group forum ID (for topic-based conversations)
+# TELEGRAM_GROUP_ID=-100xxxxxxxxx
+
+# Thread IDs for each topic (check logs: "thread=XX")
+# SPRINT_THREAD_ID=6
+# DEV_THREAD_ID=3
+# IDEAS_THREAD_ID=5
+# SERVER_THREAD_ID=7
+
 # --- OPTIONAL: Paths ---
 
 # Claude CLI path (auto-detected if in PATH)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,8 @@ jobs:
             npx pm2 restart claude-relay --update-env
             npx pm2 restart claude-dashboard --update-env
 
-            echo "Deploy complete: $(git log --oneline -1)"
+            COMMIT=$(git log --oneline -1)
+            echo "Deploy complete: $COMMIT"
+
+            # Notify serveur topic
+            bash /home/edouard/claude-telegram-relay/scripts/notify-deploy.sh "success" "$COMMIT"

--- a/scripts/notify-deploy.sh
+++ b/scripts/notify-deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Sends a deploy notification to the serveur topic on Telegram
+# Usage: notify-deploy.sh <success|failure> <commit message>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RELAY_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load env
+if [ -f "$RELAY_DIR/.env" ]; then
+    export $(grep -v '^#' "$RELAY_DIR/.env" | xargs)
+fi
+
+STATUS="${1:-unknown}"
+DETAILS="${2:-}"
+
+BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+GROUP_ID="${TELEGRAM_GROUP_ID:-}"
+SERVER_THREAD="${SERVER_THREAD_ID:-7}"
+
+if [ -z "$BOT_TOKEN" ] || [ -z "$GROUP_ID" ]; then
+    echo "[notify-deploy] Missing BOT_TOKEN or GROUP_ID"
+    exit 0
+fi
+
+HOSTNAME=$(hostname)
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M')
+
+if [ "$STATUS" = "success" ]; then
+    MESSAGE="Deploy OK ($HOSTNAME) - $TIMESTAMP
+$DETAILS
+Services redemarres."
+else
+    MESSAGE="Deploy ECHEC ($HOSTNAME) - $TIMESTAMP
+$DETAILS"
+fi
+
+curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+    -d "chat_id=${GROUP_ID}" \
+    -d "text=${MESSAGE}" \
+    -d "message_thread_id=${SERVER_THREAD}" > /dev/null 2>&1
+
+echo "[notify-deploy] Notification sent: $STATUS"

--- a/scripts/system-alerts.sh
+++ b/scripts/system-alerts.sh
@@ -15,7 +15,7 @@ fi
 BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
 GROUP_ID="${TELEGRAM_GROUP_ID:-}"
 USER_ID="${TELEGRAM_USER_ID:-}"
-SPRINT_THREAD_ID="${SPRINT_THREAD_ID:-}"
+SERVER_THREAD="${SERVER_THREAD_ID:-7}"
 
 # Prefer sending to group's serveur topic, fallback to user DM
 CHAT_ID="${GROUP_ID:-$USER_ID}"
@@ -26,10 +26,9 @@ send_alert() {
         -d "chat_id=${CHAT_ID}" \
         -d "text=${message}")
 
-    # If sending to group, use the serveur topic if known
-    # Thread ID 7 is typically the serveur topic (adjust if needed)
+    # If sending to group, use the serveur topic
     if [ -n "$GROUP_ID" ] && [ "$CHAT_ID" = "$GROUP_ID" ]; then
-        params+=(-d "message_thread_id=7")
+        params+=(-d "message_thread_id=${SERVER_THREAD}")
     fi
 
     curl "${params[@]}" > /dev/null 2>&1

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,0 +1,86 @@
+/**
+ * Proactive Notifications
+ *
+ * Sends automatic notifications to specific Telegram forum topics:
+ * - PR created/merged → claude-relay topic
+ * - Task status changes → sprint topic
+ * - Deploy events → serveur topic
+ */
+
+import type { Bot } from "grammy";
+
+const GROUP_ID = process.env.TELEGRAM_GROUP_ID || "";
+const DEV_THREAD_ID = parseInt(process.env.DEV_THREAD_ID || "0");
+const SPRINT_THREAD_ID = parseInt(process.env.SPRINT_THREAD_ID || "0");
+const SERVER_THREAD_ID = parseInt(process.env.SERVER_THREAD_ID || "0");
+
+let botInstance: Bot | null = null;
+
+export function initNotifications(bot: Bot): void {
+  botInstance = bot;
+}
+
+async function sendToTopic(threadId: number, message: string): Promise<void> {
+  if (!botInstance || !GROUP_ID || !threadId) return;
+  try {
+    await botInstance.api.sendMessage(parseInt(GROUP_ID), message, {
+      message_thread_id: threadId,
+    });
+  } catch (error) {
+    console.error(`Notification error (thread ${threadId}):`, error);
+  }
+}
+
+// ── PR Notifications → claude-relay topic ────────────────────
+
+export async function notifyPRCreated(
+  taskTitle: string,
+  prUrl: string,
+  branchName: string
+): Promise<void> {
+  const message = [
+    `PR creee: ${taskTitle}`,
+    `Branche: ${branchName}`,
+    `Lien: ${prUrl}`,
+  ].join("\n");
+  await sendToTopic(DEV_THREAD_ID, message);
+}
+
+export async function notifyPRMerged(
+  taskTitle: string,
+  prUrl: string
+): Promise<void> {
+  const message = `PR mergee: ${taskTitle}\n${prUrl}`;
+  await sendToTopic(DEV_THREAD_ID, message);
+}
+
+// ── Task Notifications → sprint topic ────────────────────────
+
+export async function notifyTaskStarted(
+  taskTitle: string,
+  taskId: string
+): Promise<void> {
+  const message = `Tache demarree: ${taskTitle} [${taskId.substring(0, 8)}]`;
+  await sendToTopic(SPRINT_THREAD_ID, message);
+}
+
+export async function notifyTaskDone(
+  taskTitle: string,
+  taskId: string
+): Promise<void> {
+  const message = `Tache terminee: ${taskTitle} [${taskId.substring(0, 8)}]`;
+  await sendToTopic(SPRINT_THREAD_ID, message);
+}
+
+// ── Deploy Notifications → serveur topic ─────────────────────
+
+export async function notifyDeploy(
+  branch: string,
+  status: "success" | "failure",
+  details?: string
+): Promise<void> {
+  const icon = status === "success" ? "OK" : "ECHEC";
+  const parts = [`Deploy ${icon}: ${branch}`];
+  if (details) parts.push(details);
+  await sendToTopic(SERVER_THREAD_ID, parts.join("\n"));
+}


### PR DESCRIPTION
## Summary
- Nouveau module src/notifications.ts pour les notifications proactives par topic
- PR creees via /exec notifiees dans le topic claude-relay
- Changements de statut de taches notifies dans le topic sprint
- Notifications de deploy dans le topic serveur via notify-deploy.sh
- Reponses vocales envoient maintenant toujours vocal + texte
- Variables d'environnement DEV_THREAD_ID, IDEAS_THREAD_ID, SERVER_THREAD_ID ajoutees

## Test plan
- [ ] Tester /exec et verifier notification dans le topic claude-relay
- [ ] Tester /done et /start depuis un topic autre que sprint
- [ ] Verifier que les reponses aux vocaux envoient bien vocal + texte
- [ ] Verifier le deploy GitHub Actions envoie une notification serveur

Generated with Claude Code