### PR TITLE
feat: S07 - CI workflow and CI-aware task execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: |
+          for f in src/*.ts dashboard/server.ts; do
+            echo "Checking $f..."
+            bun build --no-bundle --target=bun "$f" || exit 1
+          done
+
+      - name: Syntax check setup scripts
+        run: |
+          for f in setup/*.ts; do
+            echo "Checking $f..."
+            bun build --no-bundle --target=bun "$f" || exit 1
+          done


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` that runs on all PRs: type-checks every TS file with `bun build`
- Modify `/exec` in `agent.ts` to wait for CI checks after creating a PR (polls every 15s, timeout 10min)
- If CI fails, task goes to "review" status instead of "done", and the notification reflects the failure
- Update `relay.ts` to display CI status in exec results

## Test plan
- [ ] Create a PR and verify CI workflow runs
- [ ] Verify /exec waits for CI and reports status

## Sprint S07
- [x] Fermer PR #8
- [x] Creer workflow CI pour les PRs
- [ ] Configurer protection de branche master
- [x] Adapter /exec pour verifier la CI