### PR TITLE
feat: S08 - PRD workflow

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -248,6 +248,118 @@
     .col-review .column-header { border-top: 3px solid var(--yellow); }
     .col-done .column-header { border-top: 3px solid var(--green); }
 
+    /* Tabs */
+    .tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 24px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .tab {
+      padding: 10px 20px;
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+
+    .tab:hover { color: var(--text); }
+    .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+    /* PRD view */
+    .prd-view { display: none; padding: 24px; }
+    .prd-view.visible { display: block; }
+
+    .prd-list { display: flex; flex-direction: column; gap: 12px; }
+
+    .prd-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px;
+      cursor: pointer;
+      transition: border-color 0.15s;
+    }
+
+    .prd-card:hover { border-color: var(--accent); }
+
+    .prd-card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+
+    .prd-card-title { font-size: 16px; font-weight: 600; }
+
+    .prd-status {
+      font-size: 11px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+
+    .prd-status-draft { background: rgba(139, 148, 158, 0.2); color: var(--text-muted); }
+    .prd-status-approved { background: rgba(63, 185, 80, 0.2); color: var(--green); }
+    .prd-status-rejected { background: rgba(248, 81, 73, 0.2); color: var(--red); }
+    .prd-status-superseded { background: rgba(210, 153, 34, 0.2); color: var(--yellow); }
+
+    .prd-card-summary {
+      font-size: 13px;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+      line-height: 1.4;
+    }
+
+    .prd-card-meta {
+      font-size: 12px;
+      color: var(--text-muted);
+      display: flex;
+      gap: 12px;
+    }
+
+    .prd-detail {
+      display: none;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 24px;
+      margin-top: 16px;
+    }
+
+    .prd-detail.visible { display: block; }
+
+    .prd-detail-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+    }
+
+    .prd-detail-back {
+      color: var(--accent);
+      cursor: pointer;
+      font-size: 13px;
+    }
+
+    .prd-detail-content {
+      font-size: 14px;
+      line-height: 1.7;
+      white-space: pre-wrap;
+      color: var(--text);
+    }
+
+    .prd-empty {
+      text-align: center;
+      color: var(--text-muted);
+      padding: 48px 24px;
+      font-size: 14px;
+    }
+
     @media (max-width: 900px) {
       .board {
         grid-template-columns: 1fr;
@@ -261,6 +373,11 @@
     <h1>Claude Relay — Backlog</h1>
     <div class="sprint-info" id="sprint-info">Chargement...</div>
   </header>
+  <div class="tabs">
+    <div class="tab active" data-tab="kanban" onclick="switchTab('kanban')">Kanban</div>
+    <div class="tab" data-tab="prds" onclick="switchTab('prds')">PRDs</div>
+  </div>
+  <div id="kanban-view">
   <div class="filters" id="filters">
     <label>Sprint:</label>
     <button class="filter-btn active" data-sprint="all">Tous</button>
@@ -290,6 +407,18 @@
     </div>
   </div>
   <div class="status-bar" id="status-bar"></div>
+  </div>
+
+  <div class="prd-view" id="prd-view">
+    <div id="prd-list-container" class="prd-list"></div>
+    <div id="prd-detail-container" class="prd-detail">
+      <div class="prd-detail-header">
+        <span class="prd-detail-back" onclick="showPRDList()">&larr; Retour</span>
+        <span id="prd-detail-status" class="prd-status"></span>
+      </div>
+      <div id="prd-detail-content" class="prd-detail-content"></div>
+    </div>
+  </div>
 
   <script>
     const SUPABASE_URL = '__SUPABASE_URL__';
@@ -435,6 +564,95 @@
       } catch (err) {
         console.error('Load error:', err);
         document.getElementById('status-bar').textContent = `Erreur: ${err.message}`;
+      }
+    }
+
+    // ── Tabs ───────────────────────────────────────────────────
+
+    function switchTab(tab) {
+      document.querySelectorAll('.tab').forEach(t => {
+        t.classList.toggle('active', t.dataset.tab === tab);
+      });
+      document.getElementById('kanban-view').style.display = tab === 'kanban' ? '' : 'none';
+      const prdView = document.getElementById('prd-view');
+      prdView.style.display = tab === 'prds' ? 'block' : 'none';
+      if (tab === 'prds') loadPRDs();
+    }
+
+    // ── PRDs ──────────────────────────────────────────────────
+
+    let allPRDs = [];
+
+    const PRD_STATUS_LABELS = {
+      draft: 'Brouillon',
+      approved: 'Approuve',
+      rejected: 'Rejete',
+      superseded: 'Remplace',
+    };
+
+    function createPRDCard(prd) {
+      const card = document.createElement('div');
+      card.className = 'prd-card';
+      card.onclick = () => showPRDDetail(prd);
+
+      const date = new Date(prd.created_at).toLocaleDateString('fr-FR');
+      const statusLabel = PRD_STATUS_LABELS[prd.status] || prd.status;
+
+      card.innerHTML = `
+        <div class="prd-card-header">
+          <span class="prd-card-title">${escapeHtml(prd.title)}</span>
+          <span class="prd-status prd-status-${prd.status}">${statusLabel}</span>
+        </div>
+        ${prd.summary ? `<div class="prd-card-summary">${escapeHtml(prd.summary)}</div>` : ''}
+        <div class="prd-card-meta">
+          <span>${escapeHtml(prd.project)}</span>
+          <span>v${prd.version}</span>
+          <span>${date}</span>
+          <span style="font-family: monospace">${prd.id.substring(0, 8)}</span>
+        </div>
+      `;
+      return card;
+    }
+
+    function showPRDDetail(prd) {
+      document.getElementById('prd-list-container').style.display = 'none';
+      const detail = document.getElementById('prd-detail-container');
+      detail.classList.add('visible');
+
+      const statusLabel = PRD_STATUS_LABELS[prd.status] || prd.status;
+      document.getElementById('prd-detail-status').className = `prd-status prd-status-${prd.status}`;
+      document.getElementById('prd-detail-status').textContent = statusLabel;
+
+      const header = `${escapeHtml(prd.title)}\nProjet: ${escapeHtml(prd.project)} | v${prd.version} | ID: ${prd.id.substring(0, 8)}\n${'─'.repeat(60)}\n\n`;
+      document.getElementById('prd-detail-content').textContent = header + (prd.content || '');
+    }
+
+    function showPRDList() {
+      document.getElementById('prd-list-container').style.display = '';
+      document.getElementById('prd-detail-container').classList.remove('visible');
+    }
+
+    async function loadPRDs() {
+      try {
+        const res = await fetch(
+          `${API}/prds?order=created_at.desc`,
+          { headers: HEADERS }
+        );
+        allPRDs = await res.json();
+
+        const container = document.getElementById('prd-list-container');
+        container.innerHTML = '';
+
+        if (allPRDs.length === 0) {
+          container.innerHTML = '<div class="prd-empty">Aucun PRD. Utilise /prd dans Telegram pour en creer un.</div>';
+          return;
+        }
+
+        for (const prd of allPRDs) {
+          container.appendChild(createPRDCard(prd));
+        }
+      } catch (err) {
+        console.error('PRD load error:', err);
       }
     }
 

--- a/src/prd.ts
+++ b/src/prd.ts
@@ -1,0 +1,276 @@
+/**
+ * PRD (Product Requirements Document) Management
+ *
+ * Generates structured PRDs via Claude from user descriptions,
+ * stores them in Supabase, and supports a validation workflow
+ * (draft -> approved / rejected).
+ *
+ * Inspired by the BMad methodology: formalized artifacts,
+ * gate-based workflow, validation before execution.
+ */
+
+import { spawn } from "bun";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const CLAUDE_PATH = process.env.CLAUDE_PATH || "claude";
+const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
+
+export interface PRD {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  title: string;
+  summary: string | null;
+  content: string;
+  project: string;
+  status: "draft" | "approved" | "rejected" | "superseded";
+  version: number;
+  tags: string[];
+  requested_by: string | null;
+  metadata: Record<string, unknown>;
+}
+
+// ── PRD Template ─────────────────────────────────────────────
+
+const PRD_TEMPLATE = `# PRD: {TITLE}
+
+## Objectif
+Quel probleme resout cette feature ? Pourquoi est-elle importante ?
+
+## Contexte
+Situation actuelle, limitations, et ce qui motive ce changement.
+
+## Scope
+### Inclus
+- Ce qui sera fait dans cette iteration
+
+### Exclus
+- Ce qui est explicitement hors scope
+
+## Specifications fonctionnelles
+Description detaillee du comportement attendu.
+
+## Specifications techniques
+- Architecture / fichiers impactes
+- Dependances
+- Migrations DB si necessaire
+
+## Criteres de succes
+1. Critere mesurable 1
+2. Critere mesurable 2
+
+## Risques et mitigations
+| Risque | Impact | Mitigation |
+|--------|--------|------------|
+| ...    | ...    | ...        |
+
+## Plan d'implementation
+1. Etape 1
+2. Etape 2
+3. Tests et validation
+
+## Estimation
+- Complexite: faible / moyenne / haute
+- Taches estimees: N
+`;
+
+// ── Queries ──────────────────────────────────────────────────
+
+export async function generatePRD(
+  description: string,
+  project: string = "telegram-relay"
+): Promise<{ title: string; summary: string; content: string } | null> {
+  const prompt = [
+    "Tu es un product manager technique. Genere un PRD (Product Requirements Document) structure a partir de la description suivante.",
+    "",
+    `DESCRIPTION: ${description}`,
+    `PROJET: ${project}`,
+    "",
+    "Utilise exactement ce template et remplis chaque section avec du contenu pertinent et concret :",
+    "",
+    PRD_TEMPLATE,
+    "",
+    "REGLES:",
+    "- Sois concis mais precis",
+    "- Les specs techniques doivent etre concretes (noms de fichiers, APIs, tables)",
+    "- Les criteres de succes doivent etre mesurables",
+    "- Le plan d'implementation doit etre decoupable en taches",
+    "- N'utilise PAS de markdown gras (**) ni italique (*), juste du texte brut avec des titres #",
+    "",
+    "IMPORTANT: Commence ta reponse par une ligne JSON avec le titre et le resume, au format:",
+    '{"title": "Titre court du PRD", "summary": "Resume en une phrase"}',
+    "",
+    "Puis le contenu complet du PRD.",
+  ].join("\n");
+
+  try {
+    const args = [
+      CLAUDE_PATH,
+      "-p",
+      prompt,
+      "--output-format",
+      "text",
+      "--dangerously-skip-permissions",
+    ];
+
+    const proc = spawn(args, {
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: PROJECT_DIR,
+      env: { ...process.env },
+    });
+
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    // Extract JSON metadata from first line
+    const lines = output.trim().split("\n");
+    let title = "PRD sans titre";
+    let summary = "";
+    let contentStart = 0;
+
+    for (let i = 0; i < Math.min(5, lines.length); i++) {
+      const line = lines[i].trim();
+      if (line.startsWith("{")) {
+        try {
+          const meta = JSON.parse(line);
+          if (meta.title) title = meta.title;
+          if (meta.summary) summary = meta.summary;
+          contentStart = i + 1;
+          break;
+        } catch {
+          // Not valid JSON, skip
+        }
+      }
+    }
+
+    const content = lines.slice(contentStart).join("\n").trim();
+    if (!content) return null;
+
+    return { title, summary, content };
+  } catch (error) {
+    console.error("generatePRD error:", error);
+    return null;
+  }
+}
+
+export async function savePRD(
+  supabase: SupabaseClient,
+  prd: { title: string; summary: string; content: string },
+  opts?: { project?: string; tags?: string[]; requested_by?: string }
+): Promise<PRD | null> {
+  const { data, error } = await supabase
+    .from("prds")
+    .insert({
+      title: prd.title,
+      summary: prd.summary,
+      content: prd.content,
+      project: opts?.project ?? "telegram-relay",
+      tags: opts?.tags ?? [],
+      requested_by: opts?.requested_by ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("savePRD error:", error);
+    return null;
+  }
+  return data as PRD;
+}
+
+export async function getPRD(
+  supabase: SupabaseClient,
+  idPrefix: string
+): Promise<PRD | null> {
+  const { data, error } = await supabase
+    .from("prds")
+    .select("*")
+    .like("id", `${idPrefix}%`)
+    .limit(1)
+    .single();
+
+  if (error) {
+    console.error("getPRD error:", error);
+    return null;
+  }
+  return data as PRD;
+}
+
+export async function getPRDs(
+  supabase: SupabaseClient,
+  opts?: { project?: string; status?: string }
+): Promise<PRD[]> {
+  let query = supabase
+    .from("prds")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (opts?.project) query = query.eq("project", opts.project);
+  if (opts?.status) query = query.eq("status", opts.status);
+
+  const { data, error } = await query;
+  if (error) {
+    console.error("getPRDs error:", error);
+    return [];
+  }
+  return (data ?? []) as PRD[];
+}
+
+export async function updatePRDStatus(
+  supabase: SupabaseClient,
+  prdId: string,
+  status: PRD["status"]
+): Promise<PRD | null> {
+  const { data, error } = await supabase
+    .from("prds")
+    .update({ status })
+    .eq("id", prdId)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("updatePRDStatus error:", error);
+    return null;
+  }
+  return data as PRD;
+}
+
+// ── Formatting ───────────────────────────────────────────────
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: "BROUILLON",
+  approved: "APPROUVE",
+  rejected: "REJETE",
+  superseded: "REMPLACE",
+};
+
+export function formatPRDList(prds: PRD[]): string {
+  if (prds.length === 0) return "Aucun PRD. Utilise /prd <description> pour en creer un.";
+
+  const lines = ["PRDs", ""];
+
+  for (const prd of prds) {
+    const status = STATUS_LABELS[prd.status] || prd.status;
+    const id = prd.id.substring(0, 8);
+    const date = new Date(prd.created_at).toLocaleDateString("fr-FR");
+    lines.push(`[${status}] ${prd.title}  [${id}]`);
+    if (prd.summary) lines.push(`  ${prd.summary}`);
+    lines.push(`  ${date} | ${prd.project} | v${prd.version}`);
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+export function formatPRDDetail(prd: PRD): string {
+  const status = STATUS_LABELS[prd.status] || prd.status;
+  const header = [
+    `PRD: ${prd.title}`,
+    `Statut: ${status} | Projet: ${prd.project} | v${prd.version}`,
+    `ID: ${prd.id.substring(0, 8)} | Cree le ${new Date(prd.created_at).toLocaleDateString("fr-FR")}`,
+    "",
+  ].join("\n");
+
+  return header + prd.content;
+}


### PR DESCRIPTION
## Summary
- Ajout de la table `prds` dans Supabase pour stocker les PRDs
- Nouveau module `src/prd.ts` : generation de PRD via Claude, CRUD, formatage
- Commande `/prd` dans Telegram : generer, lister, consulter les PRDs
- Boutons inline Telegram pour approuver/rejeter/modifier un PRD
- Onglet PRDs dans le dashboard avec vue liste et detail

## Workflow
1. `/prd <description>` genere un PRD structure via Claude
2. Le PRD est affiche avec des boutons Approuver / Rejeter / Modifier
3. L'utilisateur valide avant de passer au code
4. Les PRDs sont visibles sur le dashboard

## Test plan
- [ ] Verifier que `/prd` sans argument liste les PRDs
- [ ] Verifier que `/prd <description>` genere et stocke un PRD
- [ ] Verifier les boutons inline (approve/reject/revise)
- [ ] Verifier l'onglet PRDs sur le dashboard
- [ ] CI passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)