### PR TITLE
test: add unit tests for notifications module

### DIFF
--- a/tests/unit/notifications.test.ts
+++ b/tests/unit/notifications.test.ts
@@ -7,12 +7,14 @@
  */
 
 import { describe, it, expect, beforeEach, mock, spyOn } from "bun:test";
-import {
-  initNotifications,
-  notifyPRCreated,
-  notifyTaskStarted,
-  notifyTaskDone,
-} from "../../src/notifications";
+
+// Set env vars BEFORE importing the module (they are read at load time)
+process.env.TELEGRAM_GROUP_ID = "123456";
+process.env.DEV_THREAD_ID = "100";
+process.env.SPRINT_THREAD_ID = "200";
+
+// Force re-import with env vars set
+const { initNotifications, notifyPRCreated, notifyTaskStarted, notifyTaskDone } = await import("../../src/notifications");
 
 function createMockBot(shouldFail = false) {
   return {


### PR DESCRIPTION
## Summary
- Ajoute 9 tests unitaires pour src/notifications.ts (module non teste jusque-la)
- Couvre les 4 fonctions exportees : initNotifications, notifyPRCreated, notifyTaskStarted, notifyTaskDone
- Tests du formatage des messages, troncature des IDs, gestion d'erreurs Telegram
- Suite complete : 281 → 290 tests, 0 fail

## Test plan
- bun test tests/unit/notifications.test.ts : 9 pass
- bun test : 290 pass, 0 fail

## Context
Quick win autonome — premier test du niveau d'autonomie 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)