### PR TITLE
feat: autonomy scanner — proactive task creation

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -55,5 +55,17 @@ module.exports = {
       merge_logs: true,
       log_date_format: "YYYY-MM-DD HH:mm:ss",
     },
+    {
+      name: "claude-autonomy-cron",
+      script: "bun",
+      args: "run src/autonomy-cron.ts",
+      cwd: "/home/edouard/claude-telegram-relay",
+      autorestart: false,
+      cron_restart: "0 8 * * *",
+      error_file: "/home/edouard/.claude-relay/logs/autonomy-cron-error.log",
+      out_file: "/home/edouard/.claude-relay/logs/autonomy-cron-out.log",
+      merge_logs: true,
+      log_date_format: "YYYY-MM-DD HH:mm:ss",
+    },
   ],
 };

--- a/src/autonomy-cron.ts
+++ b/src/autonomy-cron.ts
@@ -1,0 +1,137 @@
+/**
+ * Autonomy Cron — Proactive Task Creation
+ *
+ * Standalone script that runs periodically via PM2.
+ * Scans the project for improvement opportunities,
+ * creates tasks in Supabase (tag: auto-generated),
+ * and notifies on Telegram.
+ *
+ * Run: bun run src/autonomy-cron.ts
+ */
+
+import "dotenv/config";
+import { createClient } from "@supabase/supabase-js";
+import {
+  runAllScanners,
+  isDuplicate,
+  formatScanResult,
+  type Opportunity,
+} from "./autonomy-scanner.ts";
+import { addTask } from "./tasks.ts";
+import { getCurrentSprint } from "./tasks.ts";
+
+const SUPABASE_URL = process.env.SUPABASE_URL || "";
+const SUPABASE_KEY = process.env.SUPABASE_ANON_KEY || "";
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || "";
+const GROUP_ID = process.env.TELEGRAM_GROUP_ID || "";
+const SPRINT_THREAD_ID = parseInt(process.env.SPRINT_THREAD_ID || "0");
+const PROJECT_ROOT = process.env.PROJECT_ROOT || "/home/edouard/claude-telegram-relay";
+
+// Max tasks to create per run (avoid flooding)
+const MAX_TASKS_PER_RUN = 3;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.log("Supabase not configured, skipping autonomy scan.");
+  process.exit(0);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+async function sendTelegram(text: string): Promise<void> {
+  if (!BOT_TOKEN) return;
+
+  const chatId = GROUP_ID || process.env.TELEGRAM_USER_ID || "";
+  if (!chatId) return;
+
+  const body: Record<string, unknown> = {
+    chat_id: chatId,
+    text,
+  };
+  if (GROUP_ID && SPRINT_THREAD_ID) {
+    body.message_thread_id = SPRINT_THREAD_ID;
+  }
+
+  await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function createTaskFromOpportunity(
+  opp: Opportunity,
+  sprint: string | null
+): Promise<string | null> {
+  // Check for duplicates using dedup_key stored in notes
+  const duplicate = await isDuplicate(supabase, opp.dedup_key);
+  if (duplicate) {
+    console.log(`  Skip (duplicate): ${opp.title}`);
+    return null;
+  }
+
+  const task = await addTask(supabase, opp.title, {
+    description: opp.description,
+    priority: opp.priority,
+    sprint: sprint ?? undefined,
+    tags: ["auto-generated", opp.type],
+  });
+
+  if (!task) return null;
+
+  // Store dedup_key in notes for future duplicate detection
+  await supabase
+    .from("tasks")
+    .update({ notes: opp.dedup_key })
+    .eq("id", task.id);
+
+  return task.id;
+}
+
+async function main(): Promise<void> {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] Autonomy scan starting...`);
+
+  // Run all scanners
+  const result = await runAllScanners(PROJECT_ROOT, supabase);
+
+  if (result.opportunities.length === 0) {
+    console.log(`[${timestamp}] No opportunities found.`);
+    return;
+  }
+
+  console.log(`[${timestamp}] ${result.opportunities.length} opportunity(ies) found.`);
+
+  // Get current sprint for task assignment
+  const sprint = await getCurrentSprint(supabase);
+
+  // Create tasks for top opportunities (respect limit)
+  const created: string[] = [];
+  for (const opp of result.opportunities.slice(0, MAX_TASKS_PER_RUN)) {
+    const taskId = await createTaskFromOpportunity(opp, sprint);
+    if (taskId) {
+      created.push(opp.title);
+      console.log(`  Created: ${opp.title} [${taskId.substring(0, 8)}]`);
+    }
+  }
+
+  // Notify on Telegram
+  if (created.length > 0) {
+    const message = [
+      `[Autonomie] ${created.length} tache(s) auto-generee(s):`,
+      "",
+      ...created.map((t) => `  ${t}`),
+      "",
+      `Sprint: ${sprint || "aucun"}`,
+      `Total detecte: ${result.opportunities.length} opportunite(s)`,
+    ].join("\n");
+
+    await sendTelegram(message);
+  }
+
+  console.log(`[${timestamp}] Done. Created ${created.length} task(s).`);
+}
+
+main().catch((err) => {
+  console.error("Autonomy cron error:", err);
+  process.exit(1);
+});

--- a/src/autonomy-scanner.ts
+++ b/src/autonomy-scanner.ts
@@ -1,0 +1,265 @@
+/**
+ * Autonomy Scanner — Proactive Opportunity Detection
+ *
+ * Scans the project for improvement opportunities and returns
+ * actionable findings that can be turned into auto-generated tasks.
+ *
+ * Scanners:
+ * - Missing test coverage (src modules without corresponding tests)
+ * - TODO/FIXME markers in source code
+ * - Stuck tasks needing intervention
+ * - Stale backlog items that could be deprioritized
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { readdir } from "fs/promises";
+import { join, basename } from "path";
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface Opportunity {
+  type: "missing_tests" | "todo_marker" | "stuck_task" | "stale_backlog";
+  title: string;
+  description: string;
+  priority: number; // 1-5
+  dedup_key: string; // Used to avoid creating duplicate tasks
+}
+
+export interface ScanResult {
+  opportunities: Opportunity[];
+  scannedAt: string;
+  summary: string;
+}
+
+// ── Scanners ─────────────────────────────────────────────────
+
+/**
+ * Find src modules that have no corresponding unit test file.
+ */
+export async function scanMissingTests(projectRoot: string): Promise<Opportunity[]> {
+  const opportunities: Opportunity[] = [];
+
+  const srcDir = join(projectRoot, "src");
+  const testDir = join(projectRoot, "tests", "unit");
+
+  let srcFiles: string[];
+  let testFiles: string[];
+
+  try {
+    srcFiles = (await readdir(srcDir)).filter((f) => f.endsWith(".ts"));
+    testFiles = (await readdir(testDir)).filter((f) => f.endsWith(".test.ts"));
+  } catch {
+    return opportunities;
+  }
+
+  const testedModules = new Set(testFiles.map((f) => f.replace(".test.ts", "")));
+
+  // Modules that are standalone scripts or too large to unit test meaningfully
+  const skipModules = new Set(["relay", "alert-cron", "autonomy-cron"]);
+
+  for (const srcFile of srcFiles) {
+    const moduleName = srcFile.replace(".ts", "");
+    if (skipModules.has(moduleName)) continue;
+    if (testedModules.has(moduleName)) continue;
+
+    opportunities.push({
+      type: "missing_tests",
+      title: `Ajouter des tests pour ${moduleName}`,
+      description: `Le module src/${srcFile} n'a pas de fichier de tests unitaires correspondant.`,
+      priority: 3,
+      dedup_key: `missing_tests:${moduleName}`,
+    });
+  }
+
+  return opportunities;
+}
+
+/**
+ * Scan source files for TODO and FIXME markers.
+ */
+export async function scanTodoMarkers(projectRoot: string): Promise<Opportunity[]> {
+  const opportunities: Opportunity[] = [];
+  const srcDir = join(projectRoot, "src");
+
+  let srcFiles: string[];
+  try {
+    srcFiles = (await readdir(srcDir)).filter((f) => f.endsWith(".ts"));
+  } catch {
+    return opportunities;
+  }
+
+  for (const srcFile of srcFiles) {
+    const filePath = join(srcDir, srcFile);
+    let content: string;
+    try {
+      content = await Bun.file(filePath).text();
+    } catch {
+      continue;
+    }
+
+    const lines = content.split("\n");
+    let todoCount = 0;
+    let fixmeCount = 0;
+
+    for (const line of lines) {
+      if (/\/\/\s*TODO/i.test(line)) todoCount++;
+      if (/\/\/\s*FIXME/i.test(line)) fixmeCount++;
+    }
+
+    if (fixmeCount > 0) {
+      opportunities.push({
+        type: "todo_marker",
+        title: `Resoudre ${fixmeCount} FIXME dans ${srcFile}`,
+        description: `${fixmeCount} marqueur(s) FIXME trouves dans src/${srcFile}.`,
+        priority: 2,
+        dedup_key: `fixme:${srcFile}`,
+      });
+    }
+
+    if (todoCount >= 3) {
+      opportunities.push({
+        type: "todo_marker",
+        title: `Traiter ${todoCount} TODOs dans ${srcFile}`,
+        description: `${todoCount} marqueur(s) TODO accumules dans src/${srcFile}.`,
+        priority: 3,
+        dedup_key: `todo:${srcFile}`,
+      });
+    }
+  }
+
+  return opportunities;
+}
+
+/**
+ * Find tasks stuck in_progress for too long.
+ */
+export async function scanStuckTasks(supabase: SupabaseClient): Promise<Opportunity[]> {
+  const opportunities: Opportunity[] = [];
+  const cutoff48h = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+
+  const { data: stuckTasks } = await supabase
+    .from("tasks")
+    .select("id, title, updated_at")
+    .eq("status", "in_progress")
+    .lt("updated_at", cutoff48h);
+
+  for (const task of stuckTasks || []) {
+    const hoursStuck = Math.round(
+      (Date.now() - new Date(task.updated_at).getTime()) / (60 * 60 * 1000)
+    );
+
+    opportunities.push({
+      type: "stuck_task",
+      title: `Debloquer: ${task.title}`,
+      description: `Tache en cours depuis ${hoursStuck}h sans mise a jour. Verifier si elle est bloquee ou a terminer.`,
+      priority: 2,
+      dedup_key: `stuck:${task.id}`,
+    });
+  }
+
+  return opportunities;
+}
+
+/**
+ * Find old backlog items that might need cleanup.
+ */
+export async function scanStaleBacklog(supabase: SupabaseClient): Promise<Opportunity[]> {
+  const opportunities: Opportunity[] = [];
+  const cutoff7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: staleTasks } = await supabase
+    .from("tasks")
+    .select("id, title, created_at, sprint")
+    .eq("status", "backlog")
+    .lt("created_at", cutoff7d)
+    .limit(10);
+
+  if ((staleTasks?.length ?? 0) >= 5) {
+    opportunities.push({
+      type: "stale_backlog",
+      title: `Nettoyer le backlog (${staleTasks!.length} taches anciennes)`,
+      description: `${staleTasks!.length} taches en backlog depuis plus de 7 jours. Envisager de prioriser, reporter ou annuler.`,
+      priority: 4,
+      dedup_key: `stale_backlog:cleanup`,
+    });
+  }
+
+  return opportunities;
+}
+
+// ── Main Scanner ─────────────────────────────────────────────
+
+/**
+ * Run all scanners and return combined results.
+ */
+export async function runAllScanners(
+  projectRoot: string,
+  supabase: SupabaseClient
+): Promise<ScanResult> {
+  const allOpportunities: Opportunity[] = [];
+
+  const [missingTests, todos, stuck, stale] = await Promise.all([
+    scanMissingTests(projectRoot),
+    scanTodoMarkers(projectRoot),
+    scanStuckTasks(supabase),
+    scanStaleBacklog(supabase),
+  ]);
+
+  allOpportunities.push(...missingTests, ...todos, ...stuck, ...stale);
+
+  // Sort by priority (lower = higher priority)
+  allOpportunities.sort((a, b) => a.priority - b.priority);
+
+  const summary = allOpportunities.length === 0
+    ? "Aucune opportunite detectee. Projet en bon etat."
+    : `${allOpportunities.length} opportunite(s): ${missingTests.length} tests manquants, ${todos.length} TODOs, ${stuck.length} taches bloquees, ${stale.length} backlog.`;
+
+  return {
+    opportunities: allOpportunities,
+    scannedAt: new Date().toISOString(),
+    summary,
+  };
+}
+
+/**
+ * Check if a task with this dedup_key already exists in the backlog.
+ */
+export async function isDuplicate(
+  supabase: SupabaseClient,
+  dedupKey: string
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("tasks")
+    .select("id")
+    .contains("tags", ["auto-generated"])
+    .eq("notes", dedupKey)
+    .neq("status", "cancelled")
+    .neq("status", "done")
+    .limit(1);
+
+  return (data?.length ?? 0) > 0;
+}
+
+// ── Formatting ───────────────────────────────────────────────
+
+export function formatScanResult(result: ScanResult): string {
+  const lines: string[] = [];
+
+  lines.push(`[Scan Autonome] ${new Date(result.scannedAt).toLocaleString("fr-FR", { timeZone: "Europe/Paris" })}`);
+  lines.push("");
+  lines.push(result.summary);
+
+  if (result.opportunities.length > 0) {
+    lines.push("");
+    for (const opp of result.opportunities.slice(0, 8)) {
+      const prio = `P${opp.priority}`;
+      lines.push(`  [${prio}] ${opp.title}`);
+    }
+
+    if (result.opportunities.length > 8) {
+      lines.push(`  ... +${result.opportunities.length - 8} autres`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/tests/unit/autonomy-scanner.test.ts
+++ b/tests/unit/autonomy-scanner.test.ts
@@ -1,0 +1,289 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import {
+  scanMissingTests,
+  scanTodoMarkers,
+  scanStuckTasks,
+  scanStaleBacklog,
+  runAllScanners,
+  isDuplicate,
+  formatScanResult,
+  type ScanResult,
+} from "../../src/autonomy-scanner.ts";
+
+// ── Mock Supabase ────────────────────────────────────────────
+
+function mockSupabase(responses: Record<string, any> = {}) {
+  const defaultResponse = { data: [], error: null };
+
+  // Build a chainable mock that resolves to the right response
+  function chainable(table: string, suffix = ""): any {
+    const key = suffix ? `${table}_${suffix}` : table;
+    const response = responses[key] ?? defaultResponse;
+    const self: any = {
+      select: () => self,
+      eq: () => self,
+      lt: () => self,
+      neq: () => self,
+      not: () => self,
+      contains: () => self,
+      limit: () => Promise.resolve(response),
+      order: () => self,
+      then: (resolve: any, reject?: any) => Promise.resolve(response).then(resolve, reject),
+    };
+    return self;
+  }
+
+  return {
+    from: (table: string) => ({
+      select: (cols?: string) => {
+        // Route dedup queries (contains → auto-generated) to separate key
+        const base = chainable(table);
+        return {
+          ...base,
+          contains: () => chainable(table, "dedup"),
+        };
+      },
+    }),
+  } as any;
+}
+
+// ── scanMissingTests ────────────────────────────────────────
+
+describe("scanMissingTests", () => {
+  test("detects modules without tests", async () => {
+    const projectRoot = process.cwd();
+    const results = await scanMissingTests(projectRoot);
+
+    // Should find some modules without tests (code-review, prd, etc.)
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].type).toBe("missing_tests");
+    expect(results[0].dedup_key).toMatch(/^missing_tests:/);
+  });
+
+  test("does not flag relay or alert-cron", async () => {
+    const projectRoot = process.cwd();
+    const results = await scanMissingTests(projectRoot);
+
+    const modules = results.map((r) => r.dedup_key);
+    expect(modules).not.toContain("missing_tests:relay");
+    expect(modules).not.toContain("missing_tests:alert-cron");
+  });
+
+  test("returns empty for invalid path", async () => {
+    const results = await scanMissingTests("/nonexistent/path");
+    expect(results).toEqual([]);
+  });
+
+  test("has priority 3 for missing tests", async () => {
+    const projectRoot = process.cwd();
+    const results = await scanMissingTests(projectRoot);
+    for (const r of results) {
+      expect(r.priority).toBe(3);
+    }
+  });
+});
+
+// ── scanTodoMarkers ─────────────────────────────────────────
+
+describe("scanTodoMarkers", () => {
+  test("returns array of opportunities", async () => {
+    const projectRoot = process.cwd();
+    const results = await scanTodoMarkers(projectRoot);
+
+    // Result should be an array (may or may not have findings)
+    expect(Array.isArray(results)).toBe(true);
+    for (const r of results) {
+      expect(r.type).toBe("todo_marker");
+      expect(r.dedup_key).toMatch(/^(todo|fixme):/);
+    }
+  });
+
+  test("FIXME has priority 2, TODO has priority 3", async () => {
+    const projectRoot = process.cwd();
+    const results = await scanTodoMarkers(projectRoot);
+
+    for (const r of results) {
+      if (r.dedup_key.startsWith("fixme:")) {
+        expect(r.priority).toBe(2);
+      } else {
+        expect(r.priority).toBe(3);
+      }
+    }
+  });
+
+  test("returns empty for invalid path", async () => {
+    const results = await scanTodoMarkers("/nonexistent/path");
+    expect(results).toEqual([]);
+  });
+});
+
+// ── scanStuckTasks ──────────────────────────────────────────
+
+describe("scanStuckTasks", () => {
+  test("detects tasks stuck > 48h", async () => {
+    const oldDate = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+    const supabase = mockSupabase({
+      tasks: {
+        data: [
+          { id: "abc-123", title: "Stuck task", updated_at: oldDate },
+        ],
+        error: null,
+      },
+    });
+
+    const results = await scanStuckTasks(supabase);
+    expect(results.length).toBe(1);
+    expect(results[0].type).toBe("stuck_task");
+    expect(results[0].dedup_key).toBe("stuck:abc-123");
+    expect(results[0].priority).toBe(2);
+  });
+
+  test("returns empty when no stuck tasks", async () => {
+    const supabase = mockSupabase({ tasks: { data: [], error: null } });
+    const results = await scanStuckTasks(supabase);
+    expect(results).toEqual([]);
+  });
+
+  test("handles supabase error gracefully", async () => {
+    const supabase = mockSupabase({ tasks: { data: null, error: "fail" } });
+    const results = await scanStuckTasks(supabase);
+    expect(results).toEqual([]);
+  });
+});
+
+// ── scanStaleBacklog ────────────────────────────────────────
+
+describe("scanStaleBacklog", () => {
+  test("triggers when >= 5 stale items", async () => {
+    const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const staleTasks = Array.from({ length: 6 }, (_, i) => ({
+      id: `task-${i}`,
+      title: `Old task ${i}`,
+      created_at: oldDate,
+      sprint: "S20",
+    }));
+
+    const supabase = mockSupabase({
+      tasks: { data: staleTasks, error: null },
+    });
+
+    const results = await scanStaleBacklog(supabase);
+    expect(results.length).toBe(1);
+    expect(results[0].type).toBe("stale_backlog");
+    expect(results[0].priority).toBe(4);
+  });
+
+  test("does not trigger with < 5 items", async () => {
+    const supabase = mockSupabase({
+      tasks: { data: [{ id: "1", title: "t", created_at: "", sprint: null }], error: null },
+    });
+
+    const results = await scanStaleBacklog(supabase);
+    expect(results).toEqual([]);
+  });
+});
+
+// ── isDuplicate ─────────────────────────────────────────────
+
+describe("isDuplicate", () => {
+  test("returns true when task exists", async () => {
+    const supabase = mockSupabase({
+      tasks_dedup: { data: [{ id: "existing" }], error: null },
+    });
+
+    const result = await isDuplicate(supabase, "missing_tests:prd");
+    expect(result).toBe(true);
+  });
+
+  test("returns false when no match", async () => {
+    const supabase = mockSupabase({
+      tasks_dedup: { data: [], error: null },
+    });
+
+    const result = await isDuplicate(supabase, "missing_tests:prd");
+    expect(result).toBe(false);
+  });
+});
+
+// ── formatScanResult ────────────────────────────────────────
+
+describe("formatScanResult", () => {
+  test("formats empty result", () => {
+    const result: ScanResult = {
+      opportunities: [],
+      scannedAt: new Date().toISOString(),
+      summary: "Aucune opportunite detectee. Projet en bon etat.",
+    };
+
+    const text = formatScanResult(result);
+    expect(text).toContain("[Scan Autonome]");
+    expect(text).toContain("Aucune opportunite");
+  });
+
+  test("formats result with opportunities", () => {
+    const result: ScanResult = {
+      opportunities: [
+        {
+          type: "missing_tests",
+          title: "Ajouter des tests pour prd",
+          description: "desc",
+          priority: 3,
+          dedup_key: "missing_tests:prd",
+        },
+      ],
+      scannedAt: new Date().toISOString(),
+      summary: "1 opportunite(s)",
+    };
+
+    const text = formatScanResult(result);
+    expect(text).toContain("[P3]");
+    expect(text).toContain("prd");
+  });
+
+  test("truncates after 8 items", () => {
+    const opportunities = Array.from({ length: 12 }, (_, i) => ({
+      type: "missing_tests" as const,
+      title: `Test ${i}`,
+      description: "d",
+      priority: 3,
+      dedup_key: `t:${i}`,
+    }));
+
+    const result: ScanResult = {
+      opportunities,
+      scannedAt: new Date().toISOString(),
+      summary: "12 opportunite(s)",
+    };
+
+    const text = formatScanResult(result);
+    expect(text).toContain("... +4 autres");
+  });
+});
+
+// ── runAllScanners ──────────────────────────────────────────
+
+describe("runAllScanners", () => {
+  test("combines all scanner results", async () => {
+    const supabase = mockSupabase({
+      tasks: { data: [], error: null },
+    });
+
+    const result = await runAllScanners(process.cwd(), supabase);
+    expect(result.scannedAt).toBeTruthy();
+    expect(Array.isArray(result.opportunities)).toBe(true);
+    expect(typeof result.summary).toBe("string");
+  });
+
+  test("sorts by priority", async () => {
+    const supabase = mockSupabase({
+      tasks: { data: [], error: null },
+    });
+
+    const result = await runAllScanners(process.cwd(), supabase);
+    for (let i = 1; i < result.opportunities.length; i++) {
+      expect(result.opportunities[i].priority).toBeGreaterThanOrEqual(
+        result.opportunities[i - 1].priority
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds autonomy-scanner.ts with 4 scanners: missing tests, TODO/FIXME markers, stuck tasks, stale backlog
- Adds autonomy-cron.ts standalone script (PM2 cron, daily at 8AM)
- Deduplication via dedup_key stored in task notes — no duplicate tasks created
- Max 3 tasks created per run to avoid flooding
- Telegram notification when tasks are auto-generated
- 19 unit tests added (309 total, 0 fail)

## How it works
1. Cron runs daily at 8AM (configurable in ecosystem.config.cjs)
2. Scans project for improvement opportunities
3. Creates tasks in Supabase with tags ["auto-generated", <type>]
4. Notifies on Telegram with summary

## Test plan
- [x] 19 unit tests covering all 4 scanners + dedup + formatting
- [x] Full suite: 309 pass, 0 fail
- [ ] Deploy PM2 config and verify cron triggers