### PR TITLE
feat: S22 orchestration intelligence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `tasks.ts` | Task CRUD: backlog → in_progress → review → done lifecycle |
 | `memory.ts` | Intelligent memory: intent tags, auto-classification via GPT-4o-mini, semantic archive, ideas pipeline |
 | `gates.ts` | BMad gates: Gate 1 (PRD approval), Gate 2 (architecture), Gate 3 (code review) |
-| `orchestrator.ts` | Multi-agent pipeline: chains analyst → pm → architect → dev → qa |
+| `orchestrator.ts` | Multi-agent pipeline: structured JSON message passing, retry loop, dynamic pipeline selection |
+| `agent-schemas.ts` | Typed JSON output schemas per agent role, parsing, structured chain context |
 | `bmad-agents.ts` | 6 agent definitions (analyst, pm, architect, dev, qa, sm) with YAML templates |
 | `bmad-prompts.ts` | Context-aware prompt builder per agent |
-| `auto-pipeline.ts` | Autonomous end-to-end pipeline (PRD → arch → dev → review → done) |
+| `auto-pipeline.ts` | Autonomous end-to-end pipeline with auto pipeline selection and retries |
 | `workflow.ts` | Workflow engine: loads config/workflow.yaml, tracks state transitions |
 | `alerts.ts` | Anomaly detection: stuck tasks, rework spikes, schedule slips |
 | `patterns.ts` | Multi-sprint pattern analysis, workflow improvement proposals |
@@ -97,8 +98,14 @@ Config: `.mcp.json`. Transport: stdio. Wraps the `memory-mcp` Edge Function.
 
 **Pipelines:**
 - DEFAULT: analyst → pm → architect → dev → qa
-- QUICK: dev → qa
-- REVIEW: qa → architect
+- QUICK: dev → qa (auto-selected for bugs, fixes, docs, simple P3 tasks)
+- REVIEW: qa → architect (auto-selected for review/audit/refactor tasks)
+
+**Pipeline selection (S22):** `autoPipeline: true` enables dynamic selection based on task title/description keywords and priority. Manual override via explicit `pipeline` option.
+
+**Structured message passing (S22):** Agents produce typed JSON output (<<<JSON>>>...<<<END>>> markers). Each role has a defined schema (analyst: risks/feasibility, pm: subtasks/priorities, architect: design/decisions, dev: files/summary, qa: score/findings, sm: summary/next_steps). Downstream agents receive structured context instead of raw text.
+
+**Retry loop (S22):** `maxRetries` option (default 0). Failed agents are retried with exponential backoff (1s, 2s, 4s... max 30s). Retry metrics logged to workflow_logs.
 
 **Workflow steps** (config/workflow.yaml): request → decomposition → validation → execution → review → closure
 
@@ -124,7 +131,7 @@ config/
 db/schema.sql           Authoritative database schema
 mcp/                    MCP memory server (memory-server.ts)
 supabase/functions/     Edge Functions (embed, search, classify-thought, memory-mcp)
-tests/                  383 tests (unit + integration)
+tests/                  440 tests (unit + integration)
 scripts/                Deployment, token rotation, setup
 examples/               Onboarding examples (morning briefing, checkin, memory)
 ```
@@ -132,7 +139,7 @@ examples/               Onboarding examples (morning briefing, checkin, memory)
 ### Conventions
 
 - Runtime: Bun
-- Tests: `bun test` (383 tests, all must pass before merge)
+- Tests: `bun test` (440 tests, all must pass before merge)
 - Git workflow: feature branch → PR → CI → merge to master
 - Error handling: always destructure `{ error }` from Supabase operations and log with `console.error`
 - Telegram responses: plain text only, no markdown formatting

--- a/src/agent-schemas.ts
+++ b/src/agent-schemas.ts
@@ -1,0 +1,460 @@
+/**
+ * Structured Agent Message Schemas — S22-01/02
+ *
+ * Defines typed JSON output schemas for each BMad agent role.
+ * Replaces raw text concatenation with structured message passing
+ * between agents in the orchestration pipeline.
+ *
+ * Each agent produces a typed output that downstream agents can parse
+ * and extract exactly what they need.
+ */
+
+import type { AgentRole } from "./orchestrator.ts";
+
+// ── Per-Role Output Schemas ──────────────────────────────────
+
+export interface AnalystOutput {
+  role: "analyst";
+  analysis: string;
+  risks: Array<{
+    severity: "high" | "medium" | "low";
+    description: string;
+  }>;
+  recommendations: string[];
+  dependencies: string[];
+  feasibility: "high" | "medium" | "low";
+}
+
+export interface PmOutput {
+  role: "pm";
+  subtasks: Array<{
+    title: string;
+    description: string;
+    priority: number;
+    acceptance_criteria: string;
+    dependencies?: string[];
+  }>;
+  priorities: string[];
+  risks: string[];
+}
+
+export interface ArchitectOutput {
+  role: "architect";
+  design: string;
+  components: Array<{
+    name: string;
+    responsibility: string;
+    interactions: string[];
+  }>;
+  files_impacted: string[];
+  patterns: string[];
+  technical_risks: string[];
+  decisions: Array<{
+    decision: string;
+    rationale: string;
+    alternatives: string[];
+  }>;
+}
+
+export interface DevOutput {
+  role: "dev";
+  files_modified: string[];
+  tests_added: string[];
+  summary: string;
+  issues_encountered: string[];
+}
+
+export interface QaOutput {
+  role: "qa";
+  score: number;
+  findings: Array<{
+    severity: "critical" | "important" | "minor" | "suggestion";
+    description: string;
+    suggestion: string;
+    file?: string;
+  }>;
+  summary: string;
+  tests_missing: string[];
+}
+
+export interface SmOutput {
+  role: "sm";
+  summary: string;
+  blockers: string[];
+  next_steps: string[];
+  follow_ups: string[];
+}
+
+/** Union of all structured agent outputs */
+export type StructuredAgentOutput =
+  | AnalystOutput
+  | PmOutput
+  | ArchitectOutput
+  | DevOutput
+  | QaOutput
+  | SmOutput;
+
+// ── AgentMessage: wrapper around structured output ───────────
+
+export interface AgentMessage {
+  agentId: AgentRole;
+  agentName: string;
+  success: boolean;
+  structured: StructuredAgentOutput | null;
+  rawOutput: string;
+  durationMs: number;
+  error?: string;
+}
+
+// ── JSON Schema Descriptions (for injection into prompts) ────
+
+const SCHEMA_DESCRIPTIONS: Record<AgentRole, string> = {
+  analyst: `{
+  "role": "analyst",
+  "analysis": "resume de l'analyse (2-3 paragraphes)",
+  "risks": [{"severity": "high|medium|low", "description": "..."}],
+  "recommendations": ["action 1", "action 2"],
+  "dependencies": ["module ou systeme dont la tache depend"],
+  "feasibility": "high|medium|low"
+}`,
+  pm: `{
+  "role": "pm",
+  "subtasks": [{
+    "title": "titre court imperatif",
+    "description": "contexte technique 1-2 phrases",
+    "priority": 1,
+    "acceptance_criteria": "Given/When/Then",
+    "dependencies": ["autre sous-tache"]
+  }],
+  "priorities": ["priorite strategique 1"],
+  "risks": ["risque identifie 1"]
+}`,
+  architect: `{
+  "role": "architect",
+  "design": "description de l'architecture proposee",
+  "components": [{
+    "name": "nom du composant",
+    "responsibility": "sa responsabilite",
+    "interactions": ["composant avec lequel il interagit"]
+  }],
+  "files_impacted": ["src/fichier.ts"],
+  "patterns": ["pattern a suivre"],
+  "technical_risks": ["risque technique"],
+  "decisions": [{
+    "decision": "choix fait",
+    "rationale": "pourquoi",
+    "alternatives": ["option rejetee"]
+  }]
+}`,
+  dev: `{
+  "role": "dev",
+  "files_modified": ["src/fichier.ts"],
+  "tests_added": ["tests/fichier.test.ts"],
+  "summary": "resume de ce qui a ete fait",
+  "issues_encountered": ["probleme rencontre et comment resolu"]
+}`,
+  qa: `{
+  "role": "qa",
+  "score": 85,
+  "findings": [{
+    "severity": "critical|important|minor|suggestion",
+    "description": "probleme identifie",
+    "suggestion": "correction proposee",
+    "file": "src/fichier.ts"
+  }],
+  "summary": "resume de la review",
+  "tests_missing": ["test manquant"]
+}`,
+  sm: `{
+  "role": "sm",
+  "summary": "synthese globale",
+  "blockers": ["blocage actuel"],
+  "next_steps": ["prochaine etape"],
+  "follow_ups": ["point de suivi"]
+}`,
+};
+
+/**
+ * Get the JSON schema description for an agent role.
+ * Used to inject into agent prompts so they produce structured output.
+ */
+export function getSchemaForRole(role: AgentRole): string {
+  return SCHEMA_DESCRIPTIONS[role] || "";
+}
+
+/**
+ * Build the structured output instruction block for an agent prompt.
+ * Tells the agent to wrap its output in a JSON block.
+ */
+export function buildStructuredOutputInstructions(role: AgentRole): string {
+  const schema = getSchemaForRole(role);
+  if (!schema) return "";
+
+  return [
+    "",
+    "FORMAT DE SORTIE OBLIGATOIRE:",
+    "Tu DOIS produire ta reponse au format JSON structure.",
+    "Entoure ton JSON avec les marqueurs <<<JSON>>> et <<<END>>>.",
+    "Tu peux ecrire du texte libre avant et apres les marqueurs, mais le JSON est obligatoire.",
+    "",
+    "Schema attendu:",
+    schema,
+    "",
+    "Exemple:",
+    "<<<JSON>>>",
+    schema,
+    "<<<END>>>",
+  ].join("\n");
+}
+
+// ── Parsing ──────────────────────────────────────────────────
+
+/**
+ * Extract structured JSON from agent raw output.
+ * Looks for <<<JSON>>> ... <<<END>>> markers.
+ * Falls back to finding any JSON object in the output.
+ */
+export function parseAgentOutput(
+  rawOutput: string,
+  role: AgentRole
+): StructuredAgentOutput | null {
+  // Try marked JSON first
+  const markerMatch = rawOutput.match(
+    /<<<JSON>>>\s*([\s\S]*?)\s*<<<END>>>/
+  );
+  if (markerMatch) {
+    try {
+      const parsed = JSON.parse(markerMatch[1].trim());
+      if (validateAgentOutput(parsed, role)) {
+        return { ...parsed, role } as StructuredAgentOutput;
+      }
+    } catch {
+      // Fall through to fallback
+    }
+  }
+
+  // Fallback: find the largest JSON object in the output
+  const jsonMatches = findJsonObjects(rawOutput);
+  for (const jsonStr of jsonMatches) {
+    try {
+      const parsed = JSON.parse(jsonStr);
+      if (validateAgentOutput(parsed, role)) {
+        return { ...parsed, role } as StructuredAgentOutput;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find JSON object strings in text, sorted by length (largest first).
+ */
+function findJsonObjects(text: string): string[] {
+  const results: string[] = [];
+  let depth = 0;
+  let start = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (text[i] === "}") {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        results.push(text.substring(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+
+  // Sort by length descending (largest JSON objects first)
+  return results.sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Validate that a parsed object matches the expected schema for a role.
+ * Checks for required fields — lenient validation (missing optional fields are OK).
+ */
+export function validateAgentOutput(
+  obj: any,
+  role: AgentRole
+): boolean {
+  if (!obj || typeof obj !== "object") return false;
+
+  switch (role) {
+    case "analyst":
+      return (
+        typeof obj.analysis === "string" &&
+        Array.isArray(obj.risks) &&
+        Array.isArray(obj.recommendations)
+      );
+    case "pm":
+      return (
+        Array.isArray(obj.subtasks) &&
+        Array.isArray(obj.priorities)
+      );
+    case "architect":
+      return (
+        typeof obj.design === "string" &&
+        Array.isArray(obj.files_impacted)
+      );
+    case "dev":
+      return (
+        Array.isArray(obj.files_modified) &&
+        typeof obj.summary === "string"
+      );
+    case "qa":
+      return (
+        typeof obj.score === "number" &&
+        Array.isArray(obj.findings) &&
+        typeof obj.summary === "string"
+      );
+    case "sm":
+      return (
+        typeof obj.summary === "string" &&
+        Array.isArray(obj.next_steps)
+      );
+    default:
+      return false;
+  }
+}
+
+// ── Context Builder for Downstream Agents ────────────────────
+
+/**
+ * Build structured context from previous agent messages.
+ * Instead of dumping raw text, extracts relevant fields per role.
+ */
+export function buildStructuredChainContext(
+  messages: AgentMessage[]
+): string {
+  if (messages.length === 0) return "";
+
+  const parts: string[] = ["CONTEXTE STRUCTURE DES AGENTS PRECEDENTS:"];
+
+  for (const msg of messages) {
+    if (!msg.success) continue;
+
+    parts.push("");
+    parts.push(`--- ${msg.agentName} (${msg.agentId}) ---`);
+
+    if (msg.structured) {
+      parts.push(formatStructuredOutput(msg.structured));
+    } else {
+      // Fallback to raw output (truncated)
+      const truncated = msg.rawOutput.substring(0, 2000);
+      parts.push(truncated);
+      if (msg.rawOutput.length > 2000) parts.push("...(tronque)");
+    }
+  }
+
+  parts.push("");
+  parts.push("Utilise ces outputs comme base. Ne repete pas ce qui a deja ete fait.");
+
+  return parts.join("\n");
+}
+
+/**
+ * Format a structured output for inclusion in downstream context.
+ * Extracts the most relevant fields per role.
+ */
+function formatStructuredOutput(output: StructuredAgentOutput): string {
+  switch (output.role) {
+    case "analyst":
+      return [
+        `Analyse: ${output.analysis}`,
+        `Faisabilite: ${output.feasibility}`,
+        output.risks.length > 0
+          ? `Risques: ${output.risks.map((r) => `[${r.severity}] ${r.description}`).join("; ")}`
+          : "",
+        output.recommendations.length > 0
+          ? `Recommandations: ${output.recommendations.join("; ")}`
+          : "",
+        output.dependencies.length > 0
+          ? `Dependances: ${output.dependencies.join(", ")}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+    case "pm":
+      return [
+        `Sous-taches (${output.subtasks.length}):`,
+        ...output.subtasks.map(
+          (st, i) =>
+            `  ${i + 1}. [P${st.priority}] ${st.title}: ${st.description}`
+        ),
+        output.risks.length > 0 ? `Risques: ${output.risks.join("; ")}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+    case "architect":
+      return [
+        `Design: ${output.design}`,
+        output.components.length > 0
+          ? `Composants: ${output.components.map((c) => `${c.name} (${c.responsibility})`).join(", ")}`
+          : "",
+        output.files_impacted.length > 0
+          ? `Fichiers: ${output.files_impacted.join(", ")}`
+          : "",
+        output.decisions.length > 0
+          ? `Decisions: ${output.decisions.map((d) => `${d.decision} (${d.rationale})`).join("; ")}`
+          : "",
+        output.technical_risks.length > 0
+          ? `Risques techniques: ${output.technical_risks.join("; ")}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+    case "dev":
+      return [
+        `Resume: ${output.summary}`,
+        output.files_modified.length > 0
+          ? `Fichiers modifies: ${output.files_modified.join(", ")}`
+          : "",
+        output.tests_added.length > 0
+          ? `Tests ajoutes: ${output.tests_added.join(", ")}`
+          : "",
+        output.issues_encountered.length > 0
+          ? `Problemes: ${output.issues_encountered.join("; ")}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+    case "qa":
+      return [
+        `Score: ${output.score}/100`,
+        `Resume: ${output.summary}`,
+        output.findings.length > 0
+          ? `Findings (${output.findings.length}): ${output.findings.map((f) => `[${f.severity}] ${f.description}`).join("; ")}`
+          : "",
+        output.tests_missing.length > 0
+          ? `Tests manquants: ${output.tests_missing.join("; ")}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+    case "sm":
+      return [
+        `Synthese: ${output.summary}`,
+        output.blockers.length > 0
+          ? `Blocages: ${output.blockers.join("; ")}`
+          : "",
+        output.next_steps.length > 0
+          ? `Prochaines etapes: ${output.next_steps.join("; ")}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+    default:
+      return JSON.stringify(output, null, 2);
+  }
+}

--- a/src/auto-pipeline.ts
+++ b/src/auto-pipeline.ts
@@ -15,7 +15,13 @@ import type { Task } from "./tasks.ts";
 import { updateTaskStatus } from "./tasks.ts";
 import { executeTask } from "./agent.ts";
 import { checkGatesWithOverrides } from "./gates.ts";
-import { orchestrate, type AgentRole, type OrchestratedResult } from "./orchestrator.ts";
+import {
+  orchestrate,
+  selectPipeline,
+  classifyPipeline,
+  type AgentRole,
+  type OrchestratedResult,
+} from "./orchestrator.ts";
 import { buildStoryFile, enrichTaskWithStory } from "./story-files.ts";
 import { WorkflowTracker } from "./workflow.ts";
 
@@ -52,6 +58,10 @@ export interface PipelineOptions {
   includeAnalysis?: boolean;
   /** Skip gate checks (for overridden tasks) */
   skipGates?: boolean;
+  /** Use dynamic pipeline selection (S22-06) */
+  autoPipeline?: boolean;
+  /** Max retries per agent (S22-04) */
+  maxRetries?: number;
 }
 
 // ── Auto Pipeline ────────────────────────────────────────────
@@ -73,13 +83,21 @@ export async function runAutoPipeline(
   options: PipelineOptions = {}
 ): Promise<PipelineResult> {
   const startTime = Date.now();
-  const { onProgress, includeAnalysis = true, skipGates = false } = options;
+  const {
+    onProgress,
+    includeAnalysis = true,
+    skipGates = false,
+    autoPipeline = false,
+    maxRetries = 0,
+  } = options;
 
   const progress = async (msg: string) => {
     if (onProgress) await onProgress(msg);
   };
 
-  await progress(`AUTO-PIPELINE demarre pour: ${task.title}`);
+  // S22-06: Log pipeline classification
+  const pipelineType = autoPipeline ? classifyPipeline(task) : "DEFAULT";
+  await progress(`AUTO-PIPELINE demarre pour: ${task.title} (pipeline: ${pipelineType})`);
 
   // Track workflow
   let tracker: WorkflowTracker | undefined;
@@ -136,10 +154,15 @@ export async function runAutoPipeline(
     await progress("Phase 3/5: Analyse multi-agents (Analyst -> PM -> Architect)...");
     if (tracker) await tracker.transition("decomposition");
 
+    const analysisPipeline = autoPipeline
+      ? selectPipeline(task).filter((r) => r !== "dev" && r !== "qa")
+      : (["analyst", "pm", "architect"] as AgentRole[]);
+
     const analysisResult = await orchestrate(supabase, task, {
-      pipeline: ["analyst", "pm", "architect"] as AgentRole[],
+      pipeline: analysisPipeline,
       onProgress,
       stopOnFailure: false,
+      maxRetries,
     });
 
     const analysisOk = analysisResult.steps.filter((s) => s.success).length;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,8 +1,9 @@
 /**
- * Multi-Agent Orchestrator — S16-01
+ * Multi-Agent Orchestrator — S16-01 / S22
  *
  * Chains BMad agents in configurable sequences.
- * Supports sequential pipelines, parallel reviews, and feedback loops.
+ * S22: Structured message passing (JSON schemas), retry loop,
+ *      dynamic pipeline selection.
  *
  * Usage:
  *   const result = await orchestrate(supabase, task, {
@@ -23,6 +24,13 @@ import {
 import { getAgent, type BmadAgent } from "./bmad-agents.ts";
 import { WorkflowTracker } from "./workflow.ts";
 import { buildTaskContext } from "./document-sharding.ts";
+import {
+  type AgentMessage,
+  type StructuredAgentOutput,
+  parseAgentOutput,
+  buildStructuredOutputInstructions,
+  buildStructuredChainContext,
+} from "./agent-schemas.ts";
 
 const CLAUDE_PATH = process.env.CLAUDE_PATH || "claude";
 const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
@@ -36,8 +44,10 @@ export interface AgentStepResult {
   agentName: string;
   success: boolean;
   output: string;
+  structured: StructuredAgentOutput | null;
   error?: string;
   durationMs: number;
+  retryCount?: number;
 }
 
 export interface OrchestratedResult {
@@ -76,23 +86,17 @@ export const REVIEW_PIPELINE: AgentRole[] = ["qa", "architect"];
 
 /**
  * Run a single agent step: build prompt, call Claude, return result.
+ * S22: Uses structured output instructions and parses JSON from output.
  */
 async function runAgentStep(
   agentId: AgentRole,
   task: Task,
-  previousOutputs: AgentStepResult[],
+  previousMessages: AgentMessage[],
   shardedContext?: string
 ): Promise<AgentStepResult> {
   const startTime = Date.now();
   const agent = getAgent(agentId);
   const agentName = agent?.name || agentId;
-
-  // Build context from previous agent outputs
-  const chainContext = previousOutputs.length > 0
-    ? previousOutputs.map((r) =>
-        `--- ${r.agentName} (${r.agentId}) ---\n${r.output}`
-      ).join("\n\n")
-    : undefined;
 
   const command = AGENT_COMMAND_MAP[agentId] || agentId;
 
@@ -118,10 +122,12 @@ async function runAgentStep(
   const isolation = buildIsolationInstructions(agentId);
   prompt = `${prompt}\n\n${isolation}`;
 
-  // Add chain context from previous agents
-  if (chainContext) {
-    prompt += `\n\n---\n\nCONTEXTE DES AGENTS PRECEDENTS:\n${chainContext}`;
-    prompt += "\n\nUtilise ces outputs comme base. Ne repete pas ce qui a deja ete fait.";
+  // Add structured output instructions (S22-03)
+  prompt += buildStructuredOutputInstructions(agentId);
+
+  // Add structured chain context from previous agents (S22-01/02)
+  if (previousMessages.length > 0) {
+    prompt += `\n\n---\n\n${buildStructuredChainContext(previousMessages)}`;
   }
 
   // Specific instructions per role in orchestration
@@ -137,11 +143,18 @@ async function runAgentStep(
     const stderr = await new Response(proc.stderr).text();
     const exitCode = await proc.exited;
 
+    const rawOutput = output.trim();
+    const success = exitCode === 0;
+
+    // Parse structured output (S22-02)
+    const structured = success ? parseAgentOutput(rawOutput, agentId) : null;
+
     return {
       agentId,
       agentName,
-      success: exitCode === 0,
-      output: output.trim(),
+      success,
+      output: rawOutput,
+      structured,
       error: exitCode !== 0 ? stderr.trim() : undefined,
       durationMs: Date.now() - startTime,
     };
@@ -151,6 +164,7 @@ async function runAgentStep(
       agentName,
       success: false,
       output: "",
+      structured: null,
       error: String(error),
       durationMs: Date.now() - startTime,
     };
@@ -291,22 +305,31 @@ export interface OrchestrateOptions {
   stopOnFailure?: boolean;
   /** Skip agents that aren't relevant (e.g., analyst for simple tasks) */
   skipIfSimple?: boolean;
+  /** Max retry attempts per agent (default: 0 = no retry) */
+  maxRetries?: number;
+  /** Use dynamic pipeline selection based on task analysis (S22-06) */
+  autoPipeline?: boolean;
 }
 
 /**
  * Orchestrate a task through a pipeline of BMad agents.
  *
- * Each agent receives the outputs of all previous agents as context.
- * The pipeline stops early if a critical agent fails and stopOnFailure is true.
+ * Each agent receives structured outputs of all previous agents as context.
+ * S22: Retry loop, structured message passing, dynamic pipeline selection.
  */
 export async function orchestrate(
   supabase: SupabaseClient | null,
   task: Task,
   options: OrchestrateOptions = {}
 ): Promise<OrchestratedResult> {
-  const pipeline = options.pipeline || DEFAULT_PIPELINE;
+  // Dynamic pipeline selection (S22-06)
+  const pipeline = options.autoPipeline
+    ? selectPipeline(task, options.pipeline)
+    : (options.pipeline || DEFAULT_PIPELINE);
+  const maxRetries = options.maxRetries ?? 0;
   const startTime = Date.now();
   const steps: AgentStepResult[] = [];
+  const messages: AgentMessage[] = [];
 
   // Load sharded context for the task (PRD, architecture docs)
   let shardedContext: string | undefined;
@@ -338,13 +361,16 @@ export async function orchestrate(
     }
   }
 
+  // Log selected pipeline (S22-07)
+  const pipelineLabel = options.autoPipeline ? "auto" : "manual";
+
   if (options.onProgress) {
     const agentNames = pipeline.map((id) => {
       const a = getAgent(id);
       return a ? `${a.icon} ${a.name}` : id;
     });
     await options.onProgress(
-      `Orchestration demarree : ${agentNames.join(" -> ")}`
+      `Orchestration demarree (${pipelineLabel}) : ${agentNames.join(" -> ")}`
     );
   }
 
@@ -375,32 +401,68 @@ export async function orchestrate(
       });
     }
 
-    const result = await runAgentStep(agentId, task, steps, shardedContext);
-    steps.push(result);
+    // S22-04: Retry loop with exponential backoff
+    let result: AgentStepResult | null = null;
+    let retryCount = 0;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      result = await runAgentStep(agentId, task, messages, shardedContext);
+
+      if (result.success) break;
+
+      if (attempt < maxRetries) {
+        retryCount = attempt + 1;
+        const backoffMs = Math.min(1000 * Math.pow(2, attempt), 30000);
+        if (options.onProgress) {
+          await options.onProgress(
+            `${agentLabel} echoue, retry ${retryCount}/${maxRetries} dans ${backoffMs / 1000}s...`
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      }
+    }
+
+    // result is never null here because maxRetries >= 0 guarantees at least one iteration
+    result!.retryCount = retryCount;
+    steps.push(result!);
+
+    // Build AgentMessage for downstream agents
+    const message: AgentMessage = {
+      agentId,
+      agentName: result!.agentName,
+      success: result!.success,
+      structured: result!.structured,
+      rawOutput: result!.output,
+      durationMs: result!.durationMs,
+      error: result!.error,
+    };
+    messages.push(message);
 
     // Persist agent artifacts to the task in Supabase
-    if (result.success && supabase) {
-      await persistAgentArtifact(supabase, task.id, agentId, result.output);
+    if (result!.success && supabase) {
+      await persistAgentArtifact(supabase, task.id, agentId, result!.output);
     }
 
     if (options.onProgress) {
-      const status = result.success ? "OK" : "ECHEC";
-      const duration = Math.round(result.durationMs / 1000);
+      const status = result!.success ? "OK" : "ECHEC";
+      const duration = Math.round(result!.durationMs / 1000);
+      const retryInfo = retryCount > 0 ? ` (${retryCount} retries)` : "";
       await options.onProgress(
-        `${agentLabel} : ${status} (${duration}s)`
+        `${agentLabel} : ${status} (${duration}s)${retryInfo}`
       );
     }
 
-    // Log checkpoint
+    // Log checkpoint (S22-05: include retry metrics)
     if (tracker) {
       await tracker.logCheckpoint(
-        result.success ? "pass" : "fail",
-        `Agent ${agentId}: ${result.success ? "succes" : "echec"} en ${result.durationMs}ms`
+        result!.success ? "pass" : "fail",
+        `Agent ${agentId}: ${result!.success ? "succes" : "echec"} en ${result!.durationMs}ms` +
+          (retryCount > 0 ? ` (${retryCount} retries)` : "")
       );
     }
 
     // Stop on failure if configured
-    if (!result.success && options.stopOnFailure) {
+    if (!result!.success && options.stopOnFailure) {
       if (options.onProgress) {
         await options.onProgress(
           `Pipeline arrete: ${agentLabel} a echoue.`
@@ -415,9 +477,9 @@ export async function orchestrate(
   // Build summary
   const summary = buildOrchestrationSummary(steps, totalDurationMs);
 
-  // Log orchestration result to Supabase
+  // Log orchestration result to Supabase (S22-05/07: include retry metrics + pipeline selection)
   if (supabase) {
-    await logOrchestrationResult(supabase, task.id, steps, totalDurationMs);
+    await logOrchestrationResult(supabase, task.id, steps, totalDurationMs, pipelineLabel);
   }
 
   return {
@@ -439,12 +501,23 @@ function buildOrchestrationSummary(
   lines.push(`Duree totale: ${Math.round(totalDurationMs / 1000)}s`);
   lines.push(`Agents: ${steps.length}`);
   lines.push(`Succes: ${steps.filter((s) => s.success).length}/${steps.length}`);
+
+  const totalRetries = steps.reduce((sum, s) => sum + (s.retryCount || 0), 0);
+  if (totalRetries > 0) {
+    lines.push(`Retries: ${totalRetries}`);
+  }
+
+  const structuredCount = steps.filter((s) => s.structured).length;
+  if (structuredCount > 0) {
+    lines.push(`Sorties structurees: ${structuredCount}/${steps.length}`);
+  }
   lines.push("");
 
   for (const step of steps) {
     const status = step.success ? "OK" : "ECHEC";
     const duration = Math.round(step.durationMs / 1000);
-    lines.push(`${step.agentName} (${step.agentId}): ${status} — ${duration}s`);
+    const retryInfo = step.retryCount ? ` [${step.retryCount} retries]` : "";
+    lines.push(`${step.agentName} (${step.agentId}): ${status} — ${duration}s${retryInfo}`);
 
     // Add a brief excerpt of the output (first 200 chars)
     if (step.output) {
@@ -464,8 +537,10 @@ async function logOrchestrationResult(
   supabase: SupabaseClient,
   taskId: string,
   steps: AgentStepResult[],
-  totalDurationMs: number
+  totalDurationMs: number,
+  pipelineSelection?: string
 ): Promise<void> {
+  const totalRetries = steps.reduce((sum, s) => sum + (s.retryCount || 0), 0);
   const { error } = await supabase.from("workflow_logs").insert({
     task_id: taskId,
     step: "orchestration",
@@ -473,17 +548,104 @@ async function logOrchestrationResult(
     to_step: "orchestration_end",
     metadata: {
       pipeline: steps.map((s) => s.agentId),
+      pipelineSelection: pipelineSelection || "manual",
       results: steps.map((s) => ({
         agent: s.agentId,
         success: s.success,
         durationMs: s.durationMs,
         outputLength: s.output.length,
+        hasStructuredOutput: s.structured !== null,
+        retryCount: s.retryCount || 0,
       })),
       totalDurationMs,
+      totalRetries,
       allPassed: steps.every((s) => s.success),
     },
   });
   if (error) console.error("logOrchestrationResult error:", error);
+}
+
+// ── Dynamic Pipeline Selection (S22-06) ──────────────────────
+
+/** Keywords that indicate a bug fix task */
+const BUG_KEYWORDS = [
+  "fix", "bug", "crash", "erreur", "error", "broken", "casse",
+  "regression", "hotfix", "patch", "reparer", "corriger",
+];
+
+/** Keywords that indicate a review/QA task */
+const REVIEW_KEYWORDS = [
+  "review", "audit", "revue", "test", "qa", "qualite", "refactor",
+  "nettoyage", "cleanup", "lint", "dette", "debt",
+];
+
+/** Keywords that indicate a documentation task */
+const DOC_KEYWORDS = [
+  "doc", "documentation", "readme", "changelog", "guide", "tutoriel",
+];
+
+export type PipelineType = "DEFAULT" | "QUICK" | "REVIEW" | "DOC";
+
+/**
+ * Analyze a task and select the most appropriate pipeline.
+ *
+ * Rules:
+ *   - Bug/fix/patch/hotfix → QUICK (dev + qa)
+ *   - Review/audit/refactor → REVIEW (qa + architect)
+ *   - Documentation → QUICK (dev + qa)
+ *   - Simple priority P3 with short title → QUICK
+ *   - Everything else → DEFAULT (analyst + pm + architect + dev + qa)
+ *   - Explicit override via options.pipeline always wins
+ */
+export function selectPipeline(
+  task: Task,
+  explicitPipeline?: AgentRole[]
+): AgentRole[] {
+  if (explicitPipeline) return explicitPipeline;
+
+  const text = `${task.title} ${task.description || ""}`.toLowerCase();
+
+  if (BUG_KEYWORDS.some((kw) => text.includes(kw))) {
+    return QUICK_PIPELINE;
+  }
+
+  if (REVIEW_KEYWORDS.some((kw) => text.includes(kw))) {
+    return REVIEW_PIPELINE;
+  }
+
+  if (DOC_KEYWORDS.some((kw) => text.includes(kw))) {
+    return QUICK_PIPELINE;
+  }
+
+  // Simple tasks: short title, low priority, no subtasks
+  if (
+    task.priority >= 3 &&
+    task.title.length < 40 &&
+    (!task.subtasks || task.subtasks.length === 0)
+  ) {
+    return QUICK_PIPELINE;
+  }
+
+  return DEFAULT_PIPELINE;
+}
+
+/**
+ * Classify a task into a pipeline type (for logging/display).
+ */
+export function classifyPipeline(task: Task): PipelineType {
+  const text = `${task.title} ${task.description || ""}`.toLowerCase();
+
+  if (BUG_KEYWORDS.some((kw) => text.includes(kw))) return "QUICK";
+  if (REVIEW_KEYWORDS.some((kw) => text.includes(kw))) return "REVIEW";
+  if (DOC_KEYWORDS.some((kw) => text.includes(kw))) return "DOC";
+  if (
+    task.priority >= 3 &&
+    task.title.length < 40 &&
+    (!task.subtasks || task.subtasks.length === 0)
+  ) {
+    return "QUICK";
+  }
+  return "DEFAULT";
 }
 
 // ── Format for Telegram ──────────────────────────────────────
@@ -494,6 +656,11 @@ export function formatOrchestrationResult(result: OrchestratedResult): string {
   const statusIcon = result.success ? "OK" : "ATTENTION";
   lines.push(`ORCHESTRATION ${statusIcon}`);
   lines.push(`Duree: ${Math.round(result.totalDurationMs / 1000)}s`);
+
+  const totalRetries = result.steps.reduce((sum, s) => sum + (s.retryCount || 0), 0);
+  if (totalRetries > 0) {
+    lines.push(`Retries: ${totalRetries}`);
+  }
   lines.push("");
 
   for (const step of result.steps) {
@@ -501,7 +668,9 @@ export function formatOrchestrationResult(result: OrchestratedResult): string {
     const icon = agent?.icon || "";
     const status = step.success ? "ok" : "echec";
     const duration = Math.round(step.durationMs / 1000);
-    lines.push(`${icon} ${step.agentName} : ${status} (${duration}s)`);
+    const structuredTag = step.structured ? " [JSON]" : "";
+    const retryTag = step.retryCount ? ` (${step.retryCount} retries)` : "";
+    lines.push(`${icon} ${step.agentName} : ${status} (${duration}s)${structuredTag}${retryTag}`);
   }
 
   // Add last agent's output as the main result

--- a/tests/unit/agent-schemas.test.ts
+++ b/tests/unit/agent-schemas.test.ts
@@ -1,0 +1,532 @@
+/**
+ * Tests for Structured Agent Message Schemas — S22-01/02
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  parseAgentOutput,
+  validateAgentOutput,
+  getSchemaForRole,
+  buildStructuredOutputInstructions,
+  buildStructuredChainContext,
+  type AgentMessage,
+  type AnalystOutput,
+  type PmOutput,
+  type ArchitectOutput,
+  type DevOutput,
+  type QaOutput,
+  type SmOutput,
+} from "../../src/agent-schemas.ts";
+
+// ── Schema Descriptions ──────────────────────────────────────
+
+describe("getSchemaForRole", () => {
+  it("returns schema for all 6 roles", () => {
+    const roles = ["analyst", "pm", "architect", "dev", "qa", "sm"] as const;
+    for (const role of roles) {
+      const schema = getSchemaForRole(role);
+      expect(schema.length).toBeGreaterThan(50);
+      expect(schema).toContain(`"role": "${role}"`);
+    }
+  });
+
+  it("returns empty string for unknown role", () => {
+    expect(getSchemaForRole("unknown" as any)).toBe("");
+  });
+});
+
+// ── buildStructuredOutputInstructions ────────────────────────
+
+describe("buildStructuredOutputInstructions", () => {
+  it("includes JSON markers instructions", () => {
+    const instructions = buildStructuredOutputInstructions("analyst");
+    expect(instructions).toContain("<<<JSON>>>");
+    expect(instructions).toContain("<<<END>>>");
+    expect(instructions).toContain("FORMAT DE SORTIE OBLIGATOIRE");
+  });
+
+  it("includes the schema for the role", () => {
+    const instructions = buildStructuredOutputInstructions("qa");
+    expect(instructions).toContain('"score"');
+    expect(instructions).toContain('"findings"');
+  });
+
+  it("returns empty for unknown role", () => {
+    expect(buildStructuredOutputInstructions("unknown" as any)).toBe("");
+  });
+});
+
+// ── Validation ───────────────────────────────────────────────
+
+describe("validateAgentOutput", () => {
+  it("validates analyst output", () => {
+    expect(
+      validateAgentOutput(
+        {
+          analysis: "test",
+          risks: [{ severity: "high", description: "risk" }],
+          recommendations: ["rec1"],
+          dependencies: [],
+          feasibility: "high",
+        },
+        "analyst"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects analyst without required fields", () => {
+    expect(validateAgentOutput({ analysis: "test" }, "analyst")).toBe(false);
+    expect(validateAgentOutput({ risks: [] }, "analyst")).toBe(false);
+  });
+
+  it("validates pm output", () => {
+    expect(
+      validateAgentOutput(
+        {
+          subtasks: [{ title: "t1", description: "d", priority: 1, acceptance_criteria: "ac" }],
+          priorities: ["p1"],
+          risks: [],
+        },
+        "pm"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects pm without subtasks", () => {
+    expect(validateAgentOutput({ priorities: [] }, "pm")).toBe(false);
+  });
+
+  it("validates architect output", () => {
+    expect(
+      validateAgentOutput(
+        {
+          design: "microservices",
+          components: [],
+          files_impacted: ["src/a.ts"],
+          patterns: [],
+          technical_risks: [],
+          decisions: [],
+        },
+        "architect"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects architect without design", () => {
+    expect(
+      validateAgentOutput({ files_impacted: ["a.ts"] }, "architect")
+    ).toBe(false);
+  });
+
+  it("validates dev output", () => {
+    expect(
+      validateAgentOutput(
+        {
+          files_modified: ["src/x.ts"],
+          tests_added: [],
+          summary: "done",
+          issues_encountered: [],
+        },
+        "dev"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects dev without summary", () => {
+    expect(
+      validateAgentOutput({ files_modified: [] }, "dev")
+    ).toBe(false);
+  });
+
+  it("validates qa output", () => {
+    expect(
+      validateAgentOutput(
+        {
+          score: 85,
+          findings: [
+            { severity: "minor", description: "d", suggestion: "s" },
+          ],
+          summary: "all good",
+          tests_missing: [],
+        },
+        "qa"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects qa without score", () => {
+    expect(
+      validateAgentOutput(
+        { findings: [], summary: "ok", tests_missing: [] },
+        "qa"
+      )
+    ).toBe(false);
+  });
+
+  it("validates sm output", () => {
+    expect(
+      validateAgentOutput(
+        {
+          summary: "sprint ok",
+          blockers: [],
+          next_steps: ["deploy"],
+          follow_ups: [],
+        },
+        "sm"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects sm without next_steps", () => {
+    expect(
+      validateAgentOutput({ summary: "ok" }, "sm")
+    ).toBe(false);
+  });
+
+  it("rejects null and non-objects", () => {
+    expect(validateAgentOutput(null, "analyst")).toBe(false);
+    expect(validateAgentOutput("string", "analyst")).toBe(false);
+    expect(validateAgentOutput(42, "pm")).toBe(false);
+  });
+
+  it("rejects unknown role", () => {
+    expect(validateAgentOutput({ summary: "x" }, "unknown" as any)).toBe(false);
+  });
+});
+
+// ── Parsing ──────────────────────────────────────────────────
+
+describe("parseAgentOutput", () => {
+  it("parses marked JSON with <<<JSON>>> markers", () => {
+    const raw = `Voici mon analyse.
+
+<<<JSON>>>
+{
+  "analysis": "Le systeme est faisable",
+  "risks": [{"severity": "low", "description": "mineur"}],
+  "recommendations": ["commencer par un POC"],
+  "dependencies": ["supabase"],
+  "feasibility": "high"
+}
+<<<END>>>
+
+Voila.`;
+
+    const result = parseAgentOutput(raw, "analyst");
+    expect(result).not.toBeNull();
+    expect(result!.role).toBe("analyst");
+    expect((result as AnalystOutput).analysis).toBe("Le systeme est faisable");
+    expect((result as AnalystOutput).feasibility).toBe("high");
+  });
+
+  it("falls back to finding JSON object in text", () => {
+    const raw = `J'ai fini l'implementation. Voici le resume:
+{
+  "files_modified": ["src/relay.ts", "src/agent.ts"],
+  "tests_added": ["tests/unit/relay.test.ts"],
+  "summary": "Ajout de la commande /ideas",
+  "issues_encountered": []
+}
+Fin.`;
+
+    const result = parseAgentOutput(raw, "dev");
+    expect(result).not.toBeNull();
+    expect(result!.role).toBe("dev");
+    expect((result as DevOutput).files_modified).toContain("src/relay.ts");
+  });
+
+  it("returns null when no valid JSON found", () => {
+    const raw = "Juste du texte libre sans JSON.";
+    expect(parseAgentOutput(raw, "analyst")).toBeNull();
+  });
+
+  it("returns null when JSON doesn't match schema", () => {
+    const raw = `<<<JSON>>>
+{"name": "irrelevant", "value": 42}
+<<<END>>>`;
+    expect(parseAgentOutput(raw, "qa")).toBeNull();
+  });
+
+  it("picks the largest JSON object as fallback", () => {
+    const raw = `Small: {"a": 1}
+Big: {
+  "score": 92,
+  "findings": [],
+  "summary": "Excellent",
+  "tests_missing": ["edge case test"]
+}`;
+
+    const result = parseAgentOutput(raw, "qa");
+    expect(result).not.toBeNull();
+    expect((result as QaOutput).score).toBe(92);
+  });
+
+  it("handles malformed JSON gracefully", () => {
+    const raw = `<<<JSON>>>
+{invalid json here}
+<<<END>>>`;
+    expect(parseAgentOutput(raw, "analyst")).toBeNull();
+  });
+
+  it("parses PM output with subtasks", () => {
+    const raw = `<<<JSON>>>
+{
+  "subtasks": [
+    {"title": "Creer le schema", "description": "Table SQL", "priority": 1, "acceptance_criteria": "Given/When/Then"},
+    {"title": "Implementer l'API", "description": "REST endpoint", "priority": 2, "acceptance_criteria": "AC"}
+  ],
+  "priorities": ["schema d'abord"],
+  "risks": ["migration complexe"]
+}
+<<<END>>>`;
+
+    const result = parseAgentOutput(raw, "pm");
+    expect(result).not.toBeNull();
+    expect((result as PmOutput).subtasks).toHaveLength(2);
+    expect((result as PmOutput).risks).toContain("migration complexe");
+  });
+
+  it("parses architect output with decisions", () => {
+    const raw = `<<<JSON>>>
+{
+  "design": "Event-driven avec Supabase Realtime",
+  "components": [{"name": "EventBus", "responsibility": "routing", "interactions": ["DB"]}],
+  "files_impacted": ["src/events.ts"],
+  "patterns": ["pub-sub"],
+  "technical_risks": ["latence reseau"],
+  "decisions": [{"decision": "Supabase Realtime", "rationale": "deja en place", "alternatives": ["Redis Pub/Sub"]}]
+}
+<<<END>>>`;
+
+    const result = parseAgentOutput(raw, "architect");
+    expect(result).not.toBeNull();
+    expect((result as ArchitectOutput).decisions).toHaveLength(1);
+    expect((result as ArchitectOutput).design).toContain("Event-driven");
+  });
+
+  it("parses SM output", () => {
+    const raw = `<<<JSON>>>
+{
+  "summary": "Sprint S22 en bonne voie",
+  "blockers": [],
+  "next_steps": ["deployer en staging", "tester e2e"],
+  "follow_ups": ["review avec Edouard"]
+}
+<<<END>>>`;
+
+    const result = parseAgentOutput(raw, "sm");
+    expect(result).not.toBeNull();
+    expect((result as SmOutput).next_steps).toHaveLength(2);
+  });
+});
+
+// ── buildStructuredChainContext ──────────────────────────────
+
+describe("buildStructuredChainContext", () => {
+  it("returns empty string for no messages", () => {
+    expect(buildStructuredChainContext([])).toBe("");
+  });
+
+  it("formats structured analyst output", () => {
+    const messages: AgentMessage[] = [
+      {
+        agentId: "analyst",
+        agentName: "Mary",
+        success: true,
+        structured: {
+          role: "analyst",
+          analysis: "Tache faisable",
+          risks: [{ severity: "low", description: "mineur" }],
+          recommendations: ["POC d'abord"],
+          dependencies: ["DB"],
+          feasibility: "high",
+        },
+        rawOutput: "...",
+        durationMs: 5000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).toContain("Mary (analyst)");
+    expect(context).toContain("Tache faisable");
+    expect(context).toContain("Faisabilite: high");
+    expect(context).toContain("[low] mineur");
+    expect(context).toContain("POC d'abord");
+  });
+
+  it("falls back to raw output when no structured data", () => {
+    const messages: AgentMessage[] = [
+      {
+        agentId: "dev",
+        agentName: "Amelia",
+        success: true,
+        structured: null,
+        rawOutput: "Code modifie avec succes.",
+        durationMs: 3000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).toContain("Code modifie avec succes.");
+  });
+
+  it("skips failed agents", () => {
+    const messages: AgentMessage[] = [
+      {
+        agentId: "analyst",
+        agentName: "Mary",
+        success: false,
+        structured: null,
+        rawOutput: "erreur",
+        durationMs: 1000,
+        error: "timeout",
+      },
+      {
+        agentId: "pm",
+        agentName: "John",
+        success: true,
+        structured: {
+          role: "pm",
+          subtasks: [{ title: "t1", description: "d1", priority: 1, acceptance_criteria: "ac" }],
+          priorities: ["t1 d'abord"],
+          risks: [],
+        },
+        rawOutput: "...",
+        durationMs: 4000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).not.toContain("Mary");
+    expect(context).toContain("John (pm)");
+  });
+
+  it("formats multiple structured outputs", () => {
+    const messages: AgentMessage[] = [
+      {
+        agentId: "analyst",
+        agentName: "Mary",
+        success: true,
+        structured: {
+          role: "analyst",
+          analysis: "OK",
+          risks: [],
+          recommendations: [],
+          dependencies: [],
+          feasibility: "high",
+        },
+        rawOutput: "...",
+        durationMs: 2000,
+      },
+      {
+        agentId: "pm",
+        agentName: "John",
+        success: true,
+        structured: {
+          role: "pm",
+          subtasks: [{ title: "S1", description: "d", priority: 2, acceptance_criteria: "ac" }],
+          priorities: ["faire S1"],
+          risks: ["delai serre"],
+        },
+        rawOutput: "...",
+        durationMs: 3000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).toContain("Mary (analyst)");
+    expect(context).toContain("John (pm)");
+    expect(context).toContain("Faisabilite: high");
+    expect(context).toContain("[P2] S1");
+    expect(context).toContain("delai serre");
+  });
+
+  it("truncates long raw output at 2000 chars", () => {
+    const longOutput = "x".repeat(3000);
+    const messages: AgentMessage[] = [
+      {
+        agentId: "dev",
+        agentName: "Amelia",
+        success: true,
+        structured: null,
+        rawOutput: longOutput,
+        durationMs: 5000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).toContain("...(tronque)");
+    // Should not contain the full 3000 char string
+    expect(context.length).toBeLessThan(longOutput.length);
+  });
+
+  it("formats QA structured output with score and findings", () => {
+    const messages: AgentMessage[] = [
+      {
+        agentId: "qa",
+        agentName: "Quinn",
+        success: true,
+        structured: {
+          role: "qa",
+          score: 78,
+          findings: [
+            { severity: "important", description: "missing validation", suggestion: "add check" },
+          ],
+          summary: "Needs work",
+          tests_missing: ["edge case"],
+        },
+        rawOutput: "...",
+        durationMs: 6000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).toContain("Score: 78/100");
+    expect(context).toContain("[important] missing validation");
+    expect(context).toContain("Tests manquants: edge case");
+  });
+
+  it("formats architect structured output with decisions", () => {
+    const messages: AgentMessage[] = [
+      {
+        agentId: "architect",
+        agentName: "Winston",
+        success: true,
+        structured: {
+          role: "architect",
+          design: "Modular monolith",
+          components: [{ name: "Core", responsibility: "business logic", interactions: ["DB"] }],
+          files_impacted: ["src/core.ts", "src/db.ts"],
+          patterns: ["repository"],
+          technical_risks: ["migration"],
+          decisions: [
+            { decision: "Postgres", rationale: "already in use", alternatives: ["MongoDB"] },
+          ],
+        },
+        rawOutput: "...",
+        durationMs: 4000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).toContain("Design: Modular monolith");
+    expect(context).toContain("Core (business logic)");
+    expect(context).toContain("src/core.ts");
+    expect(context).toContain("Postgres (already in use)");
+  });
+
+  it("includes instruction for downstream agents", () => {
+    const messages: AgentMessage[] = [
+      {
+        agentId: "analyst",
+        agentName: "Mary",
+        success: true,
+        structured: null,
+        rawOutput: "ok",
+        durationMs: 1000,
+      },
+    ];
+
+    const context = buildStructuredChainContext(messages);
+    expect(context).toContain("Ne repete pas ce qui a deja ete fait");
+  });
+});

--- a/tests/unit/auto-pipeline.test.ts
+++ b/tests/unit/auto-pipeline.test.ts
@@ -140,13 +140,8 @@ describe("PipelinePhase types", () => {
 
 describe("PipelineOptions defaults", () => {
   it("includeAnalysis defaults to true (full BMad pipeline)", () => {
-    // The default options should include analysis (full mode)
-    // We verify this by checking that runAutoPipeline exists and
-    // accepts options where includeAnalysis is optional
     const defaultOpts: PipelineOptions = {};
-    // includeAnalysis should default to true in the function body
     expect(defaultOpts.includeAnalysis).toBeUndefined();
-    // When undefined, the function defaults to true (verified by code review)
   });
 
   it("skipGates can be set to true", () => {
@@ -157,6 +152,27 @@ describe("PipelineOptions defaults", () => {
   it("onProgress callback is optional", () => {
     const opts: PipelineOptions = {};
     expect(opts.onProgress).toBeUndefined();
+  });
+
+  // S22 options
+  it("autoPipeline defaults to undefined (manual)", () => {
+    const opts: PipelineOptions = {};
+    expect(opts.autoPipeline).toBeUndefined();
+  });
+
+  it("autoPipeline can be set to true", () => {
+    const opts: PipelineOptions = { autoPipeline: true };
+    expect(opts.autoPipeline).toBe(true);
+  });
+
+  it("maxRetries defaults to undefined (0)", () => {
+    const opts: PipelineOptions = {};
+    expect(opts.maxRetries).toBeUndefined();
+  });
+
+  it("maxRetries can be set", () => {
+    const opts: PipelineOptions = { maxRetries: 3 };
+    expect(opts.maxRetries).toBe(3);
   });
 });
 

--- a/tests/unit/orchestrator.test.ts
+++ b/tests/unit/orchestrator.test.ts
@@ -2,6 +2,7 @@
  * Unit Tests — src/orchestrator.ts
  *
  * Tests for the multi-agent orchestration framework.
+ * S22: Structured message passing, retry loop, dynamic pipeline selection.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -10,10 +11,13 @@ import {
   QUICK_PIPELINE,
   REVIEW_PIPELINE,
   formatOrchestrationResult,
+  selectPipeline,
+  classifyPipeline,
   type AgentRole,
   type OrchestratedResult,
   type AgentStepResult,
 } from "../../src/orchestrator";
+import type { Task } from "../../src/tasks";
 
 describe("Pipeline Definitions", () => {
   it("DEFAULT_PIPELINE includes all main agents in order", () => {
@@ -44,9 +48,18 @@ describe("formatOrchestrationResult", () => {
     agentName: string,
     success: boolean,
     output: string = "test output",
-    durationMs: number = 5000
+    durationMs: number = 5000,
+    opts?: { structured?: any; retryCount?: number }
   ): AgentStepResult {
-    return { agentId, agentName, success, output, durationMs };
+    return {
+      agentId,
+      agentName,
+      success,
+      output,
+      structured: opts?.structured ?? null,
+      durationMs,
+      retryCount: opts?.retryCount,
+    };
   }
 
   it("formats a successful orchestration", () => {
@@ -141,5 +154,198 @@ describe("formatOrchestrationResult", () => {
     expect(formatted).toContain("15s");
     expect(formatted).toContain("30s");
     expect(formatted).toContain("120s");
+  });
+
+  // S22 — Structured output and retry display
+
+  it("shows [JSON] tag for steps with structured output", () => {
+    const result: OrchestratedResult = {
+      success: true,
+      steps: [
+        makeStep("analyst", "Mary", true, "Done", 5000, {
+          structured: { role: "analyst", analysis: "ok", risks: [], recommendations: [], dependencies: [], feasibility: "high" },
+        }),
+        makeStep("dev", "Amelia", true, "Done", 10000),
+      ],
+      totalDurationMs: 15000,
+      summary: "Done",
+    };
+
+    const formatted = formatOrchestrationResult(result);
+    expect(formatted).toContain("[JSON]");
+    // Dev should NOT have [JSON]
+    const lines = formatted.split("\n");
+    const ameliaLine = lines.find((l) => l.includes("Amelia"));
+    expect(ameliaLine).not.toContain("[JSON]");
+  });
+
+  it("shows retry count in formatted output", () => {
+    const result: OrchestratedResult = {
+      success: true,
+      steps: [
+        makeStep("dev", "Amelia", true, "Done", 15000, { retryCount: 2 }),
+      ],
+      totalDurationMs: 15000,
+      summary: "Done after retries",
+    };
+
+    const formatted = formatOrchestrationResult(result);
+    expect(formatted).toContain("2 retries");
+    expect(formatted).toContain("Retries: 2");
+  });
+
+  it("does not show retries when count is 0", () => {
+    const result: OrchestratedResult = {
+      success: true,
+      steps: [makeStep("dev", "Amelia", true, "Done")],
+      totalDurationMs: 5000,
+      summary: "Done",
+    };
+
+    const formatted = formatOrchestrationResult(result);
+    expect(formatted).not.toContain("retries");
+    expect(formatted).not.toContain("Retries:");
+  });
+
+  it("shows total retries across multiple agents", () => {
+    const result: OrchestratedResult = {
+      success: true,
+      steps: [
+        makeStep("analyst", "Mary", true, "Done", 5000, { retryCount: 1 }),
+        makeStep("dev", "Amelia", true, "Done", 10000, { retryCount: 2 }),
+      ],
+      totalDurationMs: 15000,
+      summary: "Done",
+    };
+
+    const formatted = formatOrchestrationResult(result);
+    expect(formatted).toContain("Retries: 3");
+  });
+});
+
+// ── S22-06: Dynamic Pipeline Selection ───────────────────────
+
+describe("selectPipeline", () => {
+  function makeTask(overrides: Partial<Task> = {}): Task {
+    return {
+      id: "test-id",
+      title: "Test task",
+      status: "backlog",
+      priority: 2,
+      created_at: new Date().toISOString(),
+      project: "test",
+      ...overrides,
+    } as Task;
+  }
+
+  it("returns explicit pipeline when provided", () => {
+    const task = makeTask({ title: "Fix bug" });
+    const pipeline = selectPipeline(task, ["dev", "qa"]);
+    expect(pipeline).toEqual(["dev", "qa"]);
+  });
+
+  it("selects QUICK for bug fix tasks", () => {
+    const bugTitles = [
+      "Fix crash on startup",
+      "Bug: messages not delivered",
+      "Hotfix for login error",
+      "Corriger le crash du dashboard",
+      "Patch regression S21",
+    ];
+
+    for (const title of bugTitles) {
+      const task = makeTask({ title });
+      expect(selectPipeline(task)).toEqual(QUICK_PIPELINE);
+    }
+  });
+
+  it("selects REVIEW for review/audit tasks", () => {
+    const reviewTitles = [
+      "Code review module orchestrator",
+      "Audit securite des endpoints",
+      "Refactor memory module",
+      "Nettoyage du code mort",
+    ];
+
+    for (const title of reviewTitles) {
+      const task = makeTask({ title });
+      expect(selectPipeline(task)).toEqual(REVIEW_PIPELINE);
+    }
+  });
+
+  it("selects QUICK for documentation tasks", () => {
+    const docTitles = [
+      "Update README documentation",
+      "Ajouter le changelog",
+      "Guide de setup pour nouveaux devs",
+    ];
+
+    for (const title of docTitles) {
+      const task = makeTask({ title });
+      expect(selectPipeline(task)).toEqual(QUICK_PIPELINE);
+    }
+  });
+
+  it("selects QUICK for simple low-priority tasks", () => {
+    const task = makeTask({
+      title: "Add button",
+      priority: 3,
+      subtasks: null,
+    });
+    expect(selectPipeline(task)).toEqual(QUICK_PIPELINE);
+  });
+
+  it("selects DEFAULT for complex feature tasks", () => {
+    const task = makeTask({
+      title: "Implement multi-agent parallel execution with worktrees",
+      priority: 1,
+    });
+    expect(selectPipeline(task)).toEqual(DEFAULT_PIPELINE);
+  });
+
+  it("checks description as well as title", () => {
+    const task = makeTask({
+      title: "Update module",
+      description: "Fix the crash that happens on reload",
+    });
+    expect(selectPipeline(task)).toEqual(QUICK_PIPELINE);
+  });
+
+  it("does not classify P1/P2 short titles without keywords as QUICK", () => {
+    const task = makeTask({
+      title: "Add new feature",
+      priority: 1,
+    });
+    expect(selectPipeline(task)).toEqual(DEFAULT_PIPELINE);
+  });
+});
+
+describe("classifyPipeline", () => {
+  function makeTask(overrides: Partial<Task> = {}): Task {
+    return {
+      id: "test-id",
+      title: "Test task",
+      status: "backlog",
+      priority: 2,
+      created_at: new Date().toISOString(),
+      project: "test",
+      ...overrides,
+    } as Task;
+  }
+
+  it("classifies bug tasks as QUICK", () => {
+    expect(classifyPipeline(makeTask({ title: "Fix bug" }))).toBe("QUICK");
+  });
+
+  it("classifies review tasks as REVIEW", () => {
+    expect(classifyPipeline(makeTask({ title: "Code review" }))).toBe("REVIEW");
+  });
+
+  it("classifies doc tasks as DOC", () => {
+    expect(classifyPipeline(makeTask({ title: "Update documentation" }))).toBe("DOC");
+  });
+
+  it("classifies feature tasks as DEFAULT", () => {
+    expect(classifyPipeline(makeTask({ title: "Implement new auth system", priority: 1 }))).toBe("DEFAULT");
   });
 });


### PR DESCRIPTION
## Summary
- Typed JSON output schemas per agent role (analyst, pm, architect, dev, qa, sm) with <<<JSON>>>...<<<END>>> markers and lenient validation
- Retry loop with exponential backoff (1s, 2s, 4s... max 30s) and retry metrics in workflow_logs
- Dynamic pipeline selection based on task keywords and priority (bug→QUICK, feature→DEFAULT, review→REVIEW)
- Structured chain context: downstream agents receive parsed JSON instead of raw text
- 57 new tests (440 total)

## Changes
- `src/agent-schemas.ts` (new): 6 typed interfaces, schema descriptions, parsing, validation, chain context builder
- `src/orchestrator.ts`: structured message passing, retry loop, selectPipeline, classifyPipeline
- `src/auto-pipeline.ts`: autoPipeline and maxRetries options forwarded to orchestrate
- `tests/unit/agent-schemas.test.ts` (new): 42 tests
- `tests/unit/orchestrator.test.ts`: +11 tests (retries, pipeline selection, JSON tags)
- `tests/unit/auto-pipeline.test.ts`: +4 tests (autoPipeline, maxRetries)
- `CLAUDE.md`: updated module descriptions, pipeline docs, test count

## Test plan
- [x] 440 tests passing (bun test)
- [ ] Dogfooding: run /orchestrate on a real task with autoPipeline=true
- [ ] Verify retry metrics appear in workflow_logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)