### PR TITLE
feat: switch CI/CD to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,9 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -63,12 +60,9 @@ jobs:
 
   e2e:
     needs: [check]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,47 +6,41 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: ${{ secrets.SERVER_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.SERVER_PORT || 22 }}
-          script: |
-            cd /home/edouard/claude-telegram-relay
-            git fetch origin master
-            git checkout master
-            git pull origin master
+      - name: Pull latest code
+        run: |
+          cd /home/edouard/claude-telegram-relay
+          git fetch origin master
+          git checkout master
+          git pull origin master
 
-            # Install deps if package.json changed
-            if git diff --name-only HEAD~1 HEAD | grep -q "package.json"; then
-              bun install
-            fi
+      - name: Install deps if needed
+        run: |
+          cd /home/edouard/claude-telegram-relay
+          if git diff --name-only HEAD~1 HEAD | grep -q "package.json"; then
+            bun install
+          fi
 
-            # Restart services
-            npx pm2 restart claude-relay --update-env
-            npx pm2 restart claude-dashboard --update-env
+      - name: Restart services
+        run: |
+          cd /home/edouard/claude-telegram-relay
+          npx pm2 restart claude-relay --update-env
+          npx pm2 restart claude-dashboard --update-env
+          sleep 5
 
-            # Wait for services to start
-            sleep 5
+      - name: Smoke test
+        run: |
+          cd /home/edouard/claude-telegram-relay
+          COMMIT=$(git log --oneline -1)
 
-            # S29: Full smoke test suite (replaces mini health check)
-            COMMIT=$(git log --oneline -1)
-
-            if bun run smoke; then
-              echo "Deploy complete: $COMMIT (smoke test OK)"
-              bash /home/edouard/claude-telegram-relay/scripts/notify-deploy.sh "success" "$COMMIT"
-
-              # Generate and send post-merge checklist
-              bun run scripts/generate-checklist.ts 2>/dev/null || true
-            else
-              echo "SMOKE TEST FAILED — rolling back"
-              bash /home/edouard/claude-telegram-relay/scripts/notify-deploy.sh "failure" "Smoke test failed for $COMMIT — auto-rollback"
-
-              # Auto-rollback (S29-T6)
-              bash /home/edouard/claude-telegram-relay/scripts/rollback.sh "smoke test failed after deploy"
-              exit 1
-            fi
+          if bun run smoke; then
+            echo "Deploy complete: $COMMIT (smoke test OK)"
+            bash scripts/notify-deploy.sh "success" "$COMMIT" || true
+            bun run scripts/generate-checklist.ts 2>/dev/null || true
+          else
+            echo "SMOKE TEST FAILED — rolling back"
+            bash scripts/notify-deploy.sh "failure" "Smoke test failed for $COMMIT — auto-rollback" || true
+            bash scripts/rollback.sh "smoke test failed after deploy"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- CI and deploy workflows now use self-hosted runner instead of ubuntu-latest
- Deploy is local (git pull + pm2 restart + smoke test) instead of SSH-based
- Setup-bun steps removed (bun already installed on server)

## Test plan
- CI jobs should pick up the self-hosted runner and execute
- Deploy on merge should run locally on the server
- All 763 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)