### PR TITLE
feat: trust scores, double-loop learning, auto-approval (S35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `supervisor.ts` | Deterministic TypeScript supervisor: agent status tracking, retry/skip/escalate decisions, timeout, structured report with speedup ratio |
 | `fan-out.ts` | Subtask parallelism: fan-out N Dev agents in worktrees, fan-in merge branches and blackboard sections, file overlap detection |
 | `worktree.ts` | Git worktree lifecycle: create, push, merge, cleanup. Branch isolation for parallel agents |
-| `gate-evaluator.ts` | Gate evaluation: dual verification (deterministic + LLM), structured rubric scoring (4x25), evaluate-rework loop (max 2 iterations) |
+| `gate-evaluator.ts` | Gate evaluation: dual verification (deterministic + LLM), structured rubric scoring (4x25), evaluate-rework loop (max 2 iterations), trust-based auto-approval |
 | `llm-router.ts` | LLM-based router for dynamic pipeline selection: Haiku analyzes task, returns pipeline + model overrides + budget |
 | `adversarial-verifier.ts` | Clean room spec-vs-implementation drift detection, coverage scoring |
 | `agent-schemas.ts` | Typed JSON output schemas per agent role, parsing, structured chain context, JSON Schema for --json-schema flag |
@@ -51,7 +51,7 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `patterns.ts` | Multi-sprint pattern analysis, workflow improvement proposals |
 | `prd.ts` | PRD management: draft → approved/rejected |
 | `code-review.ts` | Adversarial code review before merge, --from-pr support, worktree isolation |
-| `feedback-loop.ts` | Learning from retros → permanent agent prompt enrichment |
+| `feedback-loop.ts` | Learning from retros + double-loop gate analysis → permanent agent prompt enrichment |
 | `story-files.ts` | Structured task specs (acceptance criteria, test stubs, steps) |
 | `document-sharding.ts` | Intelligent context cache: splits large docs, loads only relevant shards |
 | `workflow-propagation.ts` | Cross-project improvement voting |
@@ -71,6 +71,8 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `mcp-config.ts` | Per-role MCP tool configuration: tool allowlists, system prompt instructions for agent MCP access |
 | `pipeline-state.ts` | Pipeline checkpoint/resume: persists execution state after each agent step, enables resuming from last success |
 | `intent-detection.ts` | Intent detection spike: pattern-based natural language to command mapping, behind feature flag |
+| `trust-scores.ts` | Trust scores per agent role: confidence tracking, auto-approval logic, progressive autonomy |
+| `gate-persistence.ts` | Gate evaluation persistence to Supabase, double-loop learning from recurring rubric weaknesses |
 
 ### Telegram Commands
 
@@ -112,7 +114,7 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 
 ### Database (Supabase)
 
-Tables: `messages`, `memory`, `memory_archive`, `tasks`, `projects`, `prds`, `sprint_metrics`, `workflow_logs`, `feedback_rules`, `workflow_proposals`, `retros`, `logs`, `document_shards`, `cost_tracking`, `blackboard`, `pipeline_runs`
+Tables: `messages`, `memory`, `memory_archive`, `tasks`, `projects`, `prds`, `sprint_metrics`, `workflow_logs`, `feedback_rules`, `workflow_proposals`, `retros`, `logs`, `document_shards`, `cost_tracking`, `blackboard`, `pipeline_runs`, `gate_evaluations`, `trust_scores`
 
 RPCs: `get_recent_messages`, `get_active_goals`, `get_facts`, `get_sprint_summary`, `match_messages`, `match_memory`, `archive_old_memories`, `bump_memory_access`
 
@@ -172,6 +174,8 @@ Config: `.mcp.json`. Transport: stdio. Wraps the `memory-mcp` Edge Function.
 
 **Quality Foundations & Routing (S34):** Four improvements to gate intelligence and cost optimization. (1) Dual Verification: `gate-evaluator.ts` runs deterministic checks (tsc type check, bun test) BEFORE LLM evaluation on implementation gates. If checks fail, gate fails immediately without LLM cost. Non-implementation gates (spec, plan, tasks) skip deterministic checks. 30s timeout per check. (2) Structured Rubric Scoring: Gates score 4 dimensions x 25 points instead of single 0-100. Implementation gates: error_handling, test_coverage, code_style, spec_conformity. Spec/plan gates: completeness, traceability, clarity, feasibility. Dimension below 10 flagged as critical weakness. Total = sum of dimensions (0-100 scale preserved). (3) Model Cascade: `spawnClaudeWithCascade()` in agent.ts starts with Haiku, escalates to Sonnet then Opus on failure. Failure context from previous attempt included in escalated prompt. Explicit model override disables cascade. Cascade disabled by default (backward compatible). (4) LLM Router: `src/llm-router.ts` uses a Haiku call to analyze task and return pipeline type + per-role model overrides + budget. Replaces keyword matching in auto-pipeline when `useRouter: true`. 5s timeout with fallback to keyword-based classifyPipeline(). Feature flags: `llm_router`, `model_cascade` (both disabled by default).
 
+**Auto-improvement & Confidence (S35):** Five features for progressive autonomy and self-improvement. (1) Gate Evaluation Persistence: every `evaluateGate()` result is persisted to `gate_evaluations` table with rubric dimensions, deterministic check results, rework iteration, and auto-approval flag. (2) Trust Scores: `trust_scores` table tracks per-agent-role confidence (0-100, default 50). Pass without rework: +5, pass with rework: +1, fail: -10. Updated automatically after each gate evaluation via `evaluateAndRework()`. (3) Double-loop Learning: when a rubric dimension scores below 15/25 three or more times for an agent role, a corrective feedback rule is auto-generated in `feedback_rules` (source: `double_loop`). Injected into agent prompts via `buildFeedbackContext()`. (4) Progressive Gate Auto-approval: trust >= 80 + P3+ tasks: spec/plan/tasks gates auto-approved (skip LLM). Trust >= 90 + P3+: implementation gates auto-approved (deterministic checks still run). P1/P2 always fully evaluated. Behind `auto_gate_approval` feature flag (disabled by default). (5) /monitor Extension: shows trust scores, 5 most recent gate evaluations, and active double-loop rules.
+
 **Workflow steps** (config/workflow.yaml): request → decomposition → validation → execution → review → closure
 
 ### Infrastructure
@@ -203,7 +207,7 @@ config/
 db/schema.sql           Authoritative database schema
 mcp/                    MCP memory server (memory-server.ts)
 supabase/functions/     Edge Functions (embed, search, classify-thought, memory-mcp)
-tests/                  909 tests (unit + integration + E2E)
+tests/                  948 tests (unit + integration + E2E)
 scripts/                Deployment, token rotation, setup
 examples/               Onboarding examples (morning briefing, checkin, memory)
 ```
@@ -211,7 +215,7 @@ examples/               Onboarding examples (morning briefing, checkin, memory)
 ### Conventions
 
 - Runtime: Bun
-- Tests: `bun test` (909 tests, all must pass before merge)
+- Tests: `bun test` (948 tests, all must pass before merge)
 - Git workflow: feature branch → PR → CI (must pass) → merge to master
 - CI verification: after creating a PR, always run `./scripts/wait-ci.sh` to verify CI passes before announcing completion. Never declare a PR ready without confirmed green CI.
 - Error handling: always destructure `{ error }` from Supabase operations and log with `console.error`

--- a/config/features.json
+++ b/config/features.json
@@ -7,5 +7,6 @@
   "feature_monitoring": true,
   "intent_detection": false,
   "llm_router": false,
-  "model_cascade": false
+  "model_cascade": false,
+  "auto_gate_approval": false
 }

--- a/config/specs/s35-spec.md
+++ b/config/specs/s35-spec.md
@@ -1,0 +1,124 @@
+# S35 — Auto-amélioration & Confiance
+
+## Objectif
+
+Rendre le système capable d'apprendre de ses erreurs et de gagner en autonomie progressivement.
+Les agents qui réussissent systématiquement les gates gagnent en confiance (trust score).
+Les patterns d'erreurs récurrents enrichissent automatiquement les prompts (double-loop learning).
+
+## Prérequis
+
+- S34 : Scoring rubrique structuré (4 dimensions × 25 points) dans gate-evaluator.ts
+- S34 : Routage en cascade et routeur LLM
+
+## Functional Requirements
+
+### FR-001 : Persistance des résultats de gate (fondation)
+
+Persister les résultats complets de chaque évaluation de gate dans Supabase.
+
+**Table `gate_evaluations` :**
+- session_id, task_id, sprint_id, agent_role, gate_name
+- score (0-100), passed (boolean)
+- rubric_dimensions (JSONB : 4 dimensions avec score, feedback, critical)
+- deterministic_checks (JSONB : résultats tsc/bun test)
+- rework_iteration (0, 1, 2), rework_triggered (boolean)
+- created_at
+
+**Acceptance Criteria :**
+- AC-001 : Chaque appel à evaluateGate() persiste le résultat dans gate_evaluations
+- AC-002 : Les dimensions rubrique sont stockées avec score, feedback, et flag critical
+- AC-003 : Les résultats des checks déterministes sont stockés (check, passed, output tronqué, duration)
+- AC-004 : Le numéro d'itération rework est tracké (0 = premier essai)
+- AC-005 : Requêtes disponibles : par agent_role, par gate_name, par sprint_id
+
+### FR-002 : Trust Scores par rôle d'agent
+
+Calculer et maintenir un score de confiance par rôle d'agent basé sur l'historique des gate evaluations.
+
+**Table `trust_scores` :**
+- agent_role (PK), score (0-100, default 50), consecutive_passes, consecutive_failures
+- total_evaluations, total_passes, last_evaluation_at, updated_at
+
+**Calcul :**
+- Gate pass sans rework : +5 points (cap à 100)
+- Gate pass avec rework : +1 point
+- Gate fail (après max rework) : -10 points (floor à 0)
+- Score initial : 50 (neutre)
+- Le score reflète la fiabilité récente, pas l'historique total
+
+**Acceptance Criteria :**
+- AC-006 : Trust score calculé et mis à jour après chaque gate evaluation
+- AC-007 : Score borné entre 0 et 100
+- AC-008 : Passes consécutives et failures consécutives trackées
+- AC-009 : Score initial de 50 pour un nouveau rôle
+- AC-010 : updateTrustScore() appelé dans evaluateAndRework() après le résultat final
+
+### FR-003 : Double-loop Learning
+
+Quand un même type d'erreur rubrique est détecté 3+ fois pour un agent, enrichir automatiquement son prompt système.
+
+**Mécanisme :**
+1. Après chaque gate evaluation, analyser les dimensions rubrique avec score < 15
+2. Grouper par (agent_role, dimension_name) dans gate_evaluations
+3. Si une dimension est faible 3+ fois : générer une instruction corrective
+4. Stocker dans feedback_rules avec source = "double_loop" (vs "retro" existant)
+5. L'instruction est injectée dans le prompt via buildFeedbackContext() (existant)
+
+**Acceptance Criteria :**
+- AC-011 : Dimensions faibles (< 15/25) détectées après chaque gate evaluation
+- AC-012 : Compteur par (agent_role, dimension) maintenu
+- AC-013 : À 3+ occurrences, feedback_rule créée automatiquement avec source "double_loop"
+- AC-014 : L'instruction générée est spécifique à la dimension (pas générique)
+- AC-015 : Les règles double-loop s'affichent dans buildFeedbackContext() comme les règles retro
+- AC-016 : Pas de doublon : si une règle existe déjà pour (agent_role, dimension), mettre à jour
+
+### FR-004 : Autonomie Progressive des Gates
+
+Les gates s'auto-approuvent pour les agents avec un trust score élevé sur les tâches simples.
+
+**Seuils :**
+- Trust score >= 80 ET priorité P3+ : gate spec/plan auto-approuvée (skip LLM)
+- Trust score >= 90 ET priorité P3+ : gate implementation auto-approuvée (checks déterministes seulement, skip LLM)
+- Trust score < 80 OU priorité P1/P2 : évaluation complète (comportement actuel)
+
+**Acceptance Criteria :**
+- AC-017 : evaluateGate() vérifie le trust score avant l'évaluation LLM
+- AC-018 : Auto-approval loggée dans gate_evaluations avec flag auto_approved = true
+- AC-019 : Tâches P1/P2 toujours évaluées complètement, quel que soit le trust score
+- AC-020 : Feature flag "auto_gate_approval" (disabled par défaut)
+- AC-021 : Les checks déterministes tournent toujours, même en auto-approval
+
+### FR-005 : Dashboard Confiance dans /monitor
+
+Étendre /monitor avec les trust scores et métriques de confiance.
+
+**Affichage :**
+- Trust scores par rôle (score, passes/failures consécutives, total évaluations)
+- Décisions récentes (5 dernières gate evaluations avec résultat)
+- Règles double-loop actives (agent, dimension, instruction)
+- Gates auto-approuvées récentes (si feature flag actif)
+
+**Acceptance Criteria :**
+- AC-022 : /monitor affiche les trust scores de tous les rôles
+- AC-023 : /monitor affiche les 5 dernières gate evaluations
+- AC-024 : /monitor affiche les règles double-loop actives
+- AC-025 : Format plain text, pas de markdown
+
+## Edge Cases
+
+- EC-001 : Aucune gate evaluation en base → trust score = 50 (default), dashboard affiche "Pas de donnees"
+- EC-002 : Supabase indisponible → trust score default 50, pas d'auto-approval, warning loggé
+- EC-003 : Dimension rubrique absente (vieux format sans rubric) → ignorée pour le double-loop
+- EC-004 : Trust score à 90 mais checks déterministes échouent → gate échoue (pas d'auto-approval)
+- EC-005 : Deux pipelines concurrents modifient le même trust score → dernier écrit gagne (acceptable)
+
+## Success Criteria
+
+- 45+ nouveaux tests
+- Tous les 909+ tests existants passent
+- Trust scores calculés et persistés après chaque gate
+- Double-loop détecte et corrige les faiblesses récurrentes
+- /monitor affiche les métriques de confiance
+- Feature flag auto_gate_approval contrôle l'autonomie progressive
+- Backward compatible : comportement identique avec feature flag off

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -290,7 +290,9 @@ CREATE TABLE IF NOT EXISTS feedback_rules (
   instruction TEXT NOT NULL,
   occurrences INTEGER DEFAULT 1,
   sprints TEXT[] DEFAULT '{}',
-  active BOOLEAN DEFAULT FALSE
+  active BOOLEAN DEFAULT FALSE,
+  source TEXT DEFAULT 'retro'
+    CHECK (source IN ('retro', 'double_loop'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_feedback_rules_agent_active ON feedback_rules(agent_id, active);
@@ -450,6 +452,50 @@ CREATE TRIGGER pipeline_runs_updated_at
   FOR EACH ROW EXECUTE FUNCTION update_pipeline_runs_updated_at();
 
 -- ============================================================
+-- GATE EVALUATIONS TABLE (S35: Gate evaluation persistence)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS gate_evaluations (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  session_id TEXT NOT NULL,
+  task_id UUID REFERENCES tasks(id),
+  sprint_id TEXT,
+  agent_role TEXT NOT NULL,
+  gate_name TEXT NOT NULL,
+  score INTEGER NOT NULL DEFAULT 0,
+  passed BOOLEAN NOT NULL DEFAULT FALSE,
+  rubric_dimensions JSONB,
+  deterministic_checks JSONB,
+  rework_iteration INTEGER NOT NULL DEFAULT 0,
+  rework_triggered BOOLEAN NOT NULL DEFAULT FALSE,
+  auto_approved BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+COMMENT ON TABLE gate_evaluations IS 'Persisted gate evaluation results for trust scoring and double-loop learning (S35).';
+
+CREATE INDEX IF NOT EXISTS idx_gate_evaluations_agent_role ON gate_evaluations(agent_role);
+CREATE INDEX IF NOT EXISTS idx_gate_evaluations_gate_name ON gate_evaluations(gate_name);
+CREATE INDEX IF NOT EXISTS idx_gate_evaluations_session ON gate_evaluations(session_id);
+CREATE INDEX IF NOT EXISTS idx_gate_evaluations_created ON gate_evaluations(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gate_evaluations_sprint ON gate_evaluations(sprint_id);
+
+-- ============================================================
+-- TRUST SCORES TABLE (S35: Trust per agent role)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS trust_scores (
+  agent_role TEXT PRIMARY KEY,
+  score INTEGER NOT NULL DEFAULT 50,
+  consecutive_passes INTEGER NOT NULL DEFAULT 0,
+  consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  total_evaluations INTEGER NOT NULL DEFAULT 0,
+  total_passes INTEGER NOT NULL DEFAULT 0,
+  last_evaluation_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON TABLE trust_scores IS 'Trust scores per agent role for progressive autonomy (S35).';
+
+-- ============================================================
 -- WORKFLOW AUDIT TABLE (Configuration change tracking)
 -- ============================================================
 CREATE TABLE IF NOT EXISTS workflow_audit (
@@ -593,6 +639,14 @@ CREATE POLICY "Allow all for authenticated" ON blackboard FOR ALL USING (true);
 
 -- Memory archive: full access
 CREATE POLICY "Allow all for authenticated" ON memory_archive FOR ALL USING (true);
+
+-- Gate evaluations: full access
+ALTER TABLE gate_evaluations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all for authenticated" ON gate_evaluations FOR ALL USING (true);
+
+-- Trust scores: full access
+ALTER TABLE trust_scores ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all for authenticated" ON trust_scores FOR ALL USING (true);
 
 -- ============================================================
 -- HELPER FUNCTIONS (RPCs)

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -11,6 +11,7 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { formatTrustScores } from "./trust-scores.ts";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -485,6 +486,7 @@ export function checkModuleErrors(): Alert[] {
 
 /**
  * Format monitoring stats for /monitor command (plain text).
+ * S35: Includes trust scores section.
  */
 export function formatMonitoringStats(): string {
   const lines: string[] = ["Monitoring Production", ""];
@@ -524,6 +526,10 @@ export function formatMonitoringStats(): string {
       lines.push(`  ${mod}: ${count}`);
     }
   }
+
+  // S35: Trust scores
+  lines.push("");
+  lines.push(formatTrustScores());
 
   return lines.join("\n");
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -12,6 +12,8 @@ import type { BotContext } from "../bot-context.ts";
 import { RELAY_START_TIME } from "../bot-context.ts";
 import { formatAgentList } from "../bmad-agents.ts";
 import { formatMonitoringStats } from "../alerts.ts";
+import { formatRecentGateEvaluations } from "../trust-scores.ts";
+import { formatDoubleLoopRules } from "../gate-persistence.ts";
 
 export default function helpCommands(bctx: BotContext): Composer<Context> {
   const composer = new Composer<Context>();
@@ -171,12 +173,23 @@ export default function helpCommands(bctx: BotContext): Composer<Context> {
     }
   });
 
-  // /monitor — production monitoring stats
+  // /monitor — production monitoring stats (S35: trust scores, evaluations, double-loop)
   composer.command("monitor", async (ctx) => {
     const blocked = commandGuard(ctx, "monitor");
     if (blocked) { await ctx.reply(blocked, threadOpts(ctx)); return; }
 
-    await ctx.reply(formatMonitoringStats(), threadOpts(ctx));
+    const parts = [formatMonitoringStats()];
+
+    // S35: Recent gate evaluations and double-loop rules
+    if (supabase) {
+      const [recentEvals, dlRules] = await Promise.all([
+        formatRecentGateEvaluations(supabase),
+        formatDoubleLoopRules(supabase),
+      ]);
+      parts.push("", recentEvals, "", dlRules);
+    }
+
+    await ctx.reply(parts.join("\n"), threadOpts(ctx));
   });
 
   return composer;

--- a/src/feedback-loop.ts
+++ b/src/feedback-loop.ts
@@ -262,20 +262,40 @@ export async function processRetroFeedback(
 /**
  * Build a feedback context block to append to an agent's prompt.
  * Only includes rules that are active (2+ occurrences).
+ * S35: Also includes double-loop rules from gate evaluations.
  */
 export function buildFeedbackContext(agentId: AgentRole): string {
   const rules = getFeedbackRulesForAgent(agentId);
   if (rules.length === 0) return "";
 
-  const lines: string[] = [
-    "",
-    "APPRENTISSAGES DES RETROS PRECEDENTES:",
-    "(ces patterns ont ete detectes dans 2+ sprints, sois particulierement attentif)",
-    "",
-  ];
+  // Separate retro rules from double-loop rules
+  const retroRules = rules.filter((r) => !r.pattern.startsWith("double_loop:"));
+  const doubleLoopRules = rules.filter((r) => r.pattern.startsWith("double_loop:"));
 
-  for (const rule of rules) {
-    lines.push(`- [${rule.occurrences}x] ${rule.instruction}`);
+  const lines: string[] = [];
+
+  if (retroRules.length > 0) {
+    lines.push(
+      "",
+      "APPRENTISSAGES DES RETROS PRECEDENTES:",
+      "(ces patterns ont ete detectes dans 2+ sprints, sois particulierement attentif)",
+      "",
+    );
+    for (const rule of retroRules) {
+      lines.push(`- [${rule.occurrences}x] ${rule.instruction}`);
+    }
+  }
+
+  if (doubleLoopRules.length > 0) {
+    lines.push(
+      "",
+      "CORRECTIONS AUTOMATIQUES (double-loop learning):",
+      "(faiblesses detectees dans les evaluations de gate precedentes)",
+      "",
+    );
+    for (const rule of doubleLoopRules) {
+      lines.push(`- [${rule.occurrences}x] ${rule.instruction}`);
+    }
   }
 
   return lines.join("\n");

--- a/src/gate-evaluator.ts
+++ b/src/gate-evaluator.ts
@@ -2,6 +2,7 @@
  * @module gate-evaluator
  * @description Gate evaluation: deterministic checks + LLM-based rubric scoring at pipeline gates,
  * evaluate-rework loop (max 2 iterations). S34: dual verification + structured rubric.
+ * S35: trust score updates, gate persistence, auto-approval, double-loop learning.
  */
 
 /**
@@ -18,6 +19,9 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { readSection, writeSection, type BlackboardSections, type SectionName } from "./blackboard.ts";
 import { spawnClaude } from "./agent.ts";
 import { spawnSync } from "bun";
+import { updateTrustScore, shouldAutoApprove } from "./trust-scores.ts";
+import { persistGateEvaluation, runDoubleLoopAnalysis } from "./gate-persistence.ts";
+import { isFeatureEnabled } from "./feature-flags.ts";
 
 const EVALUATOR_TIMEOUT = 120_000; // 120s (EC-004)
 const DETERMINISTIC_CHECK_TIMEOUT = 30_000; // 30s per check (S34 EC-001)
@@ -48,6 +52,8 @@ export interface GateEvaluation {
   rubric?: RubricDimension[];
   /** S34: Deterministic check results (implementation gates only) */
   deterministicChecks?: DeterministicCheckResult[];
+  /** S35: Whether this gate was auto-approved based on trust score */
+  autoApproved?: boolean;
 }
 
 export type GateName = "spec" | "plan" | "tasks" | "implementation";
@@ -266,10 +272,25 @@ function buildRubricJsonSchema(gateName: GateName): string {
 
 // ── Evaluator ────────────────────────────────────────────────
 
+/** S35: Options for gate evaluation */
+export interface EvaluateGateOptions {
+  /** S34: Working directory for deterministic checks */
+  cwd?: string;
+  /** S35: Agent role for trust score lookup */
+  agentRole?: string;
+  /** S35: Task priority for auto-approval check */
+  taskPriority?: number;
+  /** S35: Task ID for persistence */
+  taskId?: string;
+  /** S35: Sprint ID for persistence */
+  sprintId?: string;
+}
+
 /**
  * Evaluate a gate by calling Claude CLI with the gate-specific criteria.
  * S34: Implementation gates run deterministic checks first (FR-001).
  * S34: All gates use structured rubric scoring (FR-002).
+ * S35: Auto-approval for high-trust agents on low-priority tasks.
  *
  * On timeout (EC-004): returns pass with warning.
  */
@@ -278,9 +299,64 @@ export async function evaluateGate(
   sessionId: string,
   gateName: GateName,
   sectionData: any,
-  /** S34: Working directory for deterministic checks */
-  cwd?: string
+  /** S34: Working directory for deterministic checks (or S35 options) */
+  cwdOrOptions?: string | EvaluateGateOptions
 ): Promise<GateEvaluation> {
+  // S35: Normalize options
+  const opts: EvaluateGateOptions = typeof cwdOrOptions === "string"
+    ? { cwd: cwdOrOptions }
+    : (cwdOrOptions || {});
+  const cwd = opts.cwd;
+
+  // S35: Auto-approval check for high-trust agents on low-priority tasks
+  if (
+    opts.agentRole &&
+    opts.taskPriority !== undefined &&
+    isFeatureEnabled("auto_gate_approval") &&
+    shouldAutoApprove(opts.agentRole, gateName, opts.taskPriority)
+  ) {
+    // For implementation gates, still run deterministic checks
+    if (gateName === "implementation") {
+      const detResults = runDeterministicChecks(cwd);
+      const allPassed = detResults.every((r) => r.passed);
+      if (!allPassed) {
+        // Deterministic checks failed — no auto-approval (EC-004)
+        const failedChecks = detResults.filter((r) => !r.passed);
+        return {
+          pass: false,
+          score: 0,
+          issues: failedChecks.map((r) => ({
+            severity: "critical" as const,
+            description: `Deterministic check "${r.check}" failed${r.timedOut ? " (timeout)" : ""}`,
+            suggestion: r.output.substring(0, 500),
+          })),
+          gate_name: gateName,
+          deterministicChecks: detResults,
+        };
+      }
+      // Deterministic checks passed — auto-approve without LLM
+      console.log(`evaluateGate: auto-approved ${gateName} for ${opts.agentRole} (trust-based, deterministic OK)`);
+      return {
+        pass: true,
+        score: 100,
+        issues: [],
+        gate_name: gateName,
+        deterministicChecks: detResults,
+        autoApproved: true,
+      };
+    }
+
+    // Non-implementation gates: auto-approve entirely
+    console.log(`evaluateGate: auto-approved ${gateName} for ${opts.agentRole} (trust-based)`);
+    return {
+      pass: true,
+      score: 100,
+      issues: [],
+      gate_name: gateName,
+      autoApproved: true,
+    };
+  }
+
   // S34 FR-001: Run deterministic checks for implementation gates
   let deterministicResults: DeterministicCheckResult[] | undefined;
 
@@ -479,12 +555,28 @@ export function parseRubricFromOutput(obj: any, gateName: GateName): RubricDimen
 
 // ── Evaluate-Rework Loop (T4 — FR-004) ──────────────────────
 
+/** S35: Options for evaluateAndRework */
+export interface EvaluateAndReworkOptions {
+  maxIterations?: number;
+  /** Override evaluator for testing */
+  customEvaluator?: (data: any) => Promise<GateEvaluation>;
+  /** S35: Task ID for persistence */
+  taskId?: string;
+  /** S35: Sprint ID for persistence */
+  sprintId?: string;
+  /** S35: Task priority for auto-approval */
+  taskPriority?: number;
+  /** S35: Working directory for deterministic checks */
+  cwd?: string;
+}
+
 /**
  * Run the evaluate-rework loop for a gate.
  *
  * 1. Evaluate the current output
  * 2. If rejected, re-run the producing agent with feedback
  * 3. Max 2 iterations, then continue with warning (AC-012)
+ * S35: Updates trust scores, persists evaluations, runs double-loop.
  *
  * @param runAgent - function to re-run the agent (receives feedback string)
  */
@@ -495,21 +587,62 @@ export async function evaluateAndRework(
   gateName: GateName,
   sectionData: any,
   runAgent: (feedback: string) => Promise<any>,
-  maxIterations: number = 2,
-  /** Override evaluator for testing */
+  maxIterationsOrOpts?: number | EvaluateAndReworkOptions,
+  /** Override evaluator for testing (legacy compat) */
   customEvaluator?: (data: any) => Promise<GateEvaluation>
 ): Promise<EvaluateReworkResult> {
+  // S35: Normalize options (backward compatible)
+  const opts: EvaluateAndReworkOptions = typeof maxIterationsOrOpts === "number"
+    ? { maxIterations: maxIterationsOrOpts, customEvaluator }
+    : (maxIterationsOrOpts || {});
+  if (customEvaluator && !opts.customEvaluator) opts.customEvaluator = customEvaluator;
+  const maxIterations = opts.maxIterations ?? 2;
+
   let currentData = sectionData;
   let iterations = 0;
   let passedAtIteration: number | null = null;
 
   for (let i = 0; i <= maxIterations; i++) {
-    const evaluation = customEvaluator
-      ? await customEvaluator(currentData)
-      : await evaluateGate(supabase, sessionId, gateName, currentData);
+    const evaluation = opts.customEvaluator
+      ? await opts.customEvaluator(currentData)
+      : await evaluateGate(supabase, sessionId, gateName, currentData, {
+          cwd: opts.cwd,
+          agentRole,
+          taskPriority: opts.taskPriority,
+          taskId: opts.taskId,
+          sprintId: opts.sprintId,
+        });
+
+    // S35: Persist gate evaluation
+    persistGateEvaluation(supabase, {
+      sessionId,
+      taskId: opts.taskId,
+      sprintId: opts.sprintId,
+      agentRole,
+      gateName,
+      score: evaluation.score,
+      passed: evaluation.pass,
+      rubricDimensions: evaluation.rubric,
+      deterministicChecks: evaluation.deterministicChecks,
+      reworkIteration: i,
+      reworkTriggered: !evaluation.pass && i < maxIterations,
+      autoApproved: evaluation.autoApproved || false,
+    }).catch((err) => console.error("Gate persistence error:", err));
 
     if (evaluation.pass) {
       passedAtIteration = i;
+      const hadRework = i > 0;
+
+      // S35: Update trust score
+      updateTrustScore(supabase, agentRole, { passed: true, hadRework })
+        .catch((err) => console.error("Trust score update error:", err));
+
+      // S35: Run double-loop analysis (non-blocking)
+      if (supabase) {
+        runDoubleLoopAnalysis(supabase, agentRole)
+          .catch((err) => console.error("Double-loop analysis error:", err));
+      }
+
       return { finalEvaluation: evaluation, iterations: i, passedAtIteration };
     }
 
@@ -523,6 +656,17 @@ export async function evaluateAndRework(
         description: `Gate "${gateName}" did not pass after ${maxIterations} rework iterations`,
         suggestion: "Manual review recommended",
       });
+
+      // S35: Update trust score (failure)
+      updateTrustScore(supabase, agentRole, { passed: false, hadRework: true })
+        .catch((err) => console.error("Trust score update error:", err));
+
+      // S35: Run double-loop analysis (non-blocking)
+      if (supabase) {
+        runDoubleLoopAnalysis(supabase, agentRole)
+          .catch((err) => console.error("Double-loop analysis error:", err));
+      }
+
       return { finalEvaluation: evaluation, iterations: i, passedAtIteration: null };
     }
 

--- a/src/gate-persistence.ts
+++ b/src/gate-persistence.ts
@@ -1,0 +1,224 @@
+/**
+ * @module gate-persistence
+ * @description Persists gate evaluation results to Supabase and implements
+ * double-loop learning from recurring rubric weaknesses (S35).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { GateEvaluation, RubricDimension, DeterministicCheckResult } from "./gate-evaluator.ts";
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface GateEvaluationRecord {
+  sessionId: string;
+  taskId?: string;
+  sprintId?: string;
+  agentRole: string;
+  gateName: string;
+  score: number;
+  passed: boolean;
+  rubricDimensions?: RubricDimension[];
+  deterministicChecks?: DeterministicCheckResult[];
+  reworkIteration: number;
+  reworkTriggered: boolean;
+  autoApproved: boolean;
+}
+
+export interface DimensionWeakness {
+  agentRole: string;
+  dimensionName: string;
+  count: number;
+}
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Score threshold below which a dimension is considered weak */
+const WEAK_DIMENSION_THRESHOLD = 15;
+
+/** Number of weak occurrences before generating a double-loop rule */
+const DOUBLE_LOOP_TRIGGER_COUNT = 3;
+
+// ── Persistence ──────────────────────────────────────────────
+
+/**
+ * Persist a gate evaluation result to Supabase.
+ */
+export async function persistGateEvaluation(
+  supabase: SupabaseClient | null,
+  record: GateEvaluationRecord
+): Promise<void> {
+  if (!supabase) return;
+
+  const { error } = await supabase
+    .from("gate_evaluations")
+    .insert({
+      session_id: record.sessionId,
+      task_id: record.taskId || null,
+      sprint_id: record.sprintId || null,
+      agent_role: record.agentRole,
+      gate_name: record.gateName,
+      score: record.score,
+      passed: record.passed,
+      rubric_dimensions: record.rubricDimensions || null,
+      deterministic_checks: record.deterministicChecks || null,
+      rework_iteration: record.reworkIteration,
+      rework_triggered: record.reworkTriggered,
+      auto_approved: record.autoApproved,
+    });
+
+  if (error) {
+    console.error("persistGateEvaluation error:", error);
+  }
+}
+
+// ── Double-loop Learning ─────────────────────────────────────
+
+/**
+ * Detect weak dimensions for an agent role by querying gate_evaluations.
+ * Returns dimensions that have been weak (< 15/25) 3+ times.
+ */
+export async function detectWeakDimensions(
+  supabase: SupabaseClient,
+  agentRole: string
+): Promise<DimensionWeakness[]> {
+  // Query all gate evaluations for this role with rubric data
+  const { data, error } = await supabase
+    .from("gate_evaluations")
+    .select("rubric_dimensions")
+    .eq("agent_role", agentRole)
+    .not("rubric_dimensions", "is", null)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error || !data) return [];
+
+  // Count weak dimensions
+  const weakCounts: Record<string, number> = {};
+  for (const row of data) {
+    const dims = row.rubric_dimensions as RubricDimension[] | null;
+    if (!dims) continue;
+    for (const dim of dims) {
+      if (dim.score < WEAK_DIMENSION_THRESHOLD) {
+        weakCounts[dim.name] = (weakCounts[dim.name] || 0) + 1;
+      }
+    }
+  }
+
+  // Filter to those at/above trigger count
+  return Object.entries(weakCounts)
+    .filter(([, count]) => count >= DOUBLE_LOOP_TRIGGER_COUNT)
+    .map(([name, count]) => ({ agentRole, dimensionName: name, count }));
+}
+
+/**
+ * Generate a corrective instruction for a weak dimension.
+ * Returns a specific instruction based on the dimension name.
+ */
+export function generateDoubleLoopInstruction(
+  agentRole: string,
+  dimensionName: string,
+  weaknessCount: number
+): string {
+  const instructions: Record<string, string> = {
+    // Code rubric dimensions
+    error_handling: `ALERTE QUALITE: La gestion d'erreurs est systematiquement faible (${weaknessCount} evaluations). Ajoute des try/catch sur les operations async, destructure {error} sur les appels Supabase, et log les erreurs avec console.error.`,
+    test_coverage: `ALERTE QUALITE: La couverture de tests est insuffisante (${weaknessCount} evaluations). Chaque nouvelle fonction doit avoir au minimum un test unitaire. Vise 80%+ de couverture sur le code ajoute.`,
+    code_style: `ALERTE QUALITE: Le style de code ne respecte pas les conventions (${weaknessCount} evaluations). Respecte les conventions TypeScript du projet: types explicites, nommage coherent, pas de any sauf necessite.`,
+    spec_conformity: `ALERTE QUALITE: L'implementation s'ecarte souvent de la spec (${weaknessCount} evaluations). Verifie chaque acceptance criteria avant de terminer. Compare ton output avec les FR de la spec.`,
+    // Spec rubric dimensions
+    completeness: `ALERTE QUALITE: Les specs manquent de completude (${weaknessCount} evaluations). Assure-toi que chaque FR a des AC, que les edge cases sont couverts, et que les success criteria sont mesurables.`,
+    traceability: `ALERTE QUALITE: La tracabilite est faible (${weaknessCount} evaluations). Chaque tache doit referencer un FR-XXX, chaque AC doit etre mappee a un test.`,
+    clarity: `ALERTE QUALITE: Les specs manquent de clarte (${weaknessCount} evaluations). Utilise un langage precis, evite les ambiguites, definis les termes techniques.`,
+    feasibility: `ALERTE QUALITE: La faisabilite est souvent mal evaluee (${weaknessCount} evaluations). Verifie les contraintes techniques, les dependances, et les risques avant de valider un plan.`,
+  };
+
+  return instructions[dimensionName] ||
+    `ALERTE QUALITE: La dimension "${dimensionName}" est systematiquement faible (${weaknessCount} evaluations). Porte une attention particuliere a cet aspect.`;
+}
+
+/**
+ * Run double-loop analysis after a gate evaluation.
+ * If weak dimensions are detected 3+ times, create feedback rules.
+ */
+export async function runDoubleLoopAnalysis(
+  supabase: SupabaseClient | null,
+  agentRole: string
+): Promise<{ rulesCreated: number; rulesUpdated: number }> {
+  if (!supabase) return { rulesCreated: 0, rulesUpdated: 0 };
+
+  const weaknesses = await detectWeakDimensions(supabase, agentRole);
+  let rulesCreated = 0;
+  let rulesUpdated = 0;
+
+  for (const weakness of weaknesses) {
+    const instruction = generateDoubleLoopInstruction(
+      agentRole,
+      weakness.dimensionName,
+      weakness.count
+    );
+
+    // Check if a double-loop rule already exists for this (role, dimension)
+    const { data: existing } = await supabase
+      .from("feedback_rules")
+      .select("id, occurrences")
+      .eq("agent_id", agentRole)
+      .eq("pattern", `double_loop:${weakness.dimensionName}`)
+      .maybeSingle();
+
+    if (existing) {
+      // Update existing rule
+      await supabase
+        .from("feedback_rules")
+        .update({
+          instruction,
+          occurrences: weakness.count,
+          active: true,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", existing.id);
+      rulesUpdated++;
+    } else {
+      // Create new rule
+      const { error } = await supabase
+        .from("feedback_rules")
+        .insert({
+          agent_id: agentRole,
+          pattern: `double_loop:${weakness.dimensionName}`,
+          instruction,
+          occurrences: weakness.count,
+          sprints: [],
+          active: true,
+          source: "double_loop",
+        });
+
+      if (!error) rulesCreated++;
+    }
+  }
+
+  return { rulesCreated, rulesUpdated };
+}
+
+/**
+ * Format double-loop rules for display.
+ */
+export async function formatDoubleLoopRules(
+  supabase: SupabaseClient | null
+): Promise<string> {
+  if (!supabase) return "Pas de connexion Supabase";
+
+  const { data, error } = await supabase
+    .from("feedback_rules")
+    .select("agent_id, pattern, instruction, occurrences")
+    .like("pattern", "double_loop:%")
+    .eq("active", true)
+    .order("occurrences", { ascending: false });
+
+  if (error || !data || data.length === 0) return "Aucune regle double-loop active";
+
+  const lines: string[] = ["Regles double-loop:"];
+  for (const rule of data) {
+    const dim = rule.pattern.replace("double_loop:", "");
+    lines.push(`  ${rule.agent_id}/${dim} [${rule.occurrences}x]`);
+  }
+  return lines.join("\n");
+}

--- a/src/trust-scores.ts
+++ b/src/trust-scores.ts
@@ -1,0 +1,239 @@
+/**
+ * @module trust-scores
+ * @description Trust scores per agent role: tracks gate evaluation success/failure
+ * to build confidence and enable progressive autonomy (S35).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface TrustScore {
+  agentRole: string;
+  score: number; // 0-100, default 50
+  consecutivePasses: number;
+  consecutiveFailures: number;
+  totalEvaluations: number;
+  totalPasses: number;
+  lastEvaluationAt: string | null;
+  updatedAt: string;
+}
+
+export interface TrustScoreUpdate {
+  passed: boolean;
+  hadRework: boolean;
+}
+
+// ── Constants ────────────────────────────────────────────────
+
+const DEFAULT_SCORE = 50;
+const PASS_NO_REWORK_DELTA = 5;
+const PASS_WITH_REWORK_DELTA = 1;
+const FAIL_DELTA = -10;
+const MIN_SCORE = 0;
+const MAX_SCORE = 100;
+
+/** Auto-approval thresholds */
+export const AUTO_APPROVE_SPEC_THRESHOLD = 80;
+export const AUTO_APPROVE_IMPL_THRESHOLD = 90;
+export const AUTO_APPROVE_MAX_PRIORITY = 3; // P3+ only (P3, P4, P5)
+
+// ── In-memory cache ──────────────────────────────────────────
+
+const trustScoreCache: Record<string, TrustScore> = {};
+
+export function getCachedTrustScores(): Record<string, TrustScore> {
+  return { ...trustScoreCache };
+}
+
+export function getCachedTrustScore(role: string): TrustScore {
+  return trustScoreCache[role] || makeDefaultTrustScore(role);
+}
+
+function makeDefaultTrustScore(role: string): TrustScore {
+  return {
+    agentRole: role,
+    score: DEFAULT_SCORE,
+    consecutivePasses: 0,
+    consecutiveFailures: 0,
+    totalEvaluations: 0,
+    totalPasses: 0,
+    lastEvaluationAt: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ── Load from Supabase ───────────────────────────────────────
+
+export async function loadTrustScores(
+  supabase: SupabaseClient
+): Promise<Record<string, TrustScore>> {
+  const { data, error } = await supabase
+    .from("trust_scores")
+    .select("*");
+
+  if (error) {
+    console.error("loadTrustScores error:", error);
+    return trustScoreCache;
+  }
+
+  for (const row of data || []) {
+    trustScoreCache[row.agent_role] = {
+      agentRole: row.agent_role,
+      score: row.score,
+      consecutivePasses: row.consecutive_passes,
+      consecutiveFailures: row.consecutive_failures,
+      totalEvaluations: row.total_evaluations,
+      totalPasses: row.total_passes,
+      lastEvaluationAt: row.last_evaluation_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  return trustScoreCache;
+}
+
+// ── Update Trust Score ───────────────────────────────────────
+
+/**
+ * Update the trust score for an agent role after a gate evaluation.
+ * - Pass without rework: +5
+ * - Pass with rework: +1
+ * - Fail (after max rework): -10
+ */
+export async function updateTrustScore(
+  supabase: SupabaseClient | null,
+  agentRole: string,
+  update: TrustScoreUpdate
+): Promise<TrustScore> {
+  const current = trustScoreCache[agentRole] || makeDefaultTrustScore(agentRole);
+
+  // Calculate delta
+  let delta: number;
+  if (update.passed && !update.hadRework) {
+    delta = PASS_NO_REWORK_DELTA;
+  } else if (update.passed && update.hadRework) {
+    delta = PASS_WITH_REWORK_DELTA;
+  } else {
+    delta = FAIL_DELTA;
+  }
+
+  // Apply
+  const newScore = Math.max(MIN_SCORE, Math.min(MAX_SCORE, current.score + delta));
+
+  const updated: TrustScore = {
+    agentRole,
+    score: newScore,
+    consecutivePasses: update.passed ? current.consecutivePasses + 1 : 0,
+    consecutiveFailures: update.passed ? 0 : current.consecutiveFailures + 1,
+    totalEvaluations: current.totalEvaluations + 1,
+    totalPasses: current.totalPasses + (update.passed ? 1 : 0),
+    lastEvaluationAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  // Update cache
+  trustScoreCache[agentRole] = updated;
+
+  // Persist to Supabase
+  if (supabase) {
+    const { error } = await supabase
+      .from("trust_scores")
+      .upsert({
+        agent_role: agentRole,
+        score: updated.score,
+        consecutive_passes: updated.consecutivePasses,
+        consecutive_failures: updated.consecutiveFailures,
+        total_evaluations: updated.totalEvaluations,
+        total_passes: updated.totalPasses,
+        last_evaluation_at: updated.lastEvaluationAt,
+        updated_at: updated.updatedAt,
+      }, { onConflict: "agent_role" });
+
+    if (error) {
+      console.error("updateTrustScore persist error:", error);
+    }
+  }
+
+  return updated;
+}
+
+// ── Auto-Approval Check ──────────────────────────────────────
+
+/**
+ * Check if a gate can be auto-approved based on trust score.
+ * Returns true if auto-approval is warranted.
+ *
+ * Rules:
+ * - Trust >= 80 + P3+: spec/plan/tasks gates auto-approved
+ * - Trust >= 90 + P3+: implementation gate auto-approved (deterministic checks still run)
+ * - P1/P2: never auto-approved
+ */
+export function shouldAutoApprove(
+  agentRole: string,
+  gateName: string,
+  taskPriority: number
+): boolean {
+  // P1/P2 always requires full evaluation
+  if (taskPriority < AUTO_APPROVE_MAX_PRIORITY) return false;
+
+  const trust = getCachedTrustScore(agentRole);
+
+  if (gateName === "implementation") {
+    return trust.score >= AUTO_APPROVE_IMPL_THRESHOLD;
+  }
+
+  // spec, plan, tasks gates
+  return trust.score >= AUTO_APPROVE_SPEC_THRESHOLD;
+}
+
+// ── Formatting ───────────────────────────────────────────────
+
+export function formatTrustScores(): string {
+  const roles = Object.keys(trustScoreCache);
+  if (roles.length === 0) return "Pas de donnees de confiance";
+
+  const lines: string[] = ["Trust scores par role:"];
+  for (const role of roles.sort()) {
+    const ts = trustScoreCache[role];
+    const passRate = ts.totalEvaluations > 0
+      ? Math.round((ts.totalPasses / ts.totalEvaluations) * 100)
+      : 0;
+    lines.push(`  ${role}: ${ts.score}/100 (${ts.consecutivePasses} passes consecutives, ${passRate}% succes, ${ts.totalEvaluations} evals)`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Format recent gate evaluations for /monitor.
+ */
+export async function formatRecentGateEvaluations(
+  supabase: SupabaseClient | null
+): Promise<string> {
+  if (!supabase) return "Pas de connexion Supabase";
+
+  const { data, error } = await supabase
+    .from("gate_evaluations")
+    .select("agent_role, gate_name, score, passed, auto_approved, created_at")
+    .order("created_at", { ascending: false })
+    .limit(5);
+
+  if (error || !data || data.length === 0) return "Aucune evaluation recente";
+
+  const lines: string[] = ["Evaluations recentes:"];
+  for (const row of data) {
+    const status = row.auto_approved ? "AUTO" : (row.passed ? "PASS" : "FAIL");
+    const date = new Date(row.created_at).toLocaleString("fr-FR", { timeZone: "Europe/Paris" });
+    lines.push(`  ${row.agent_role}/${row.gate_name}: ${status} (${row.score}/100) ${date}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Reset trust score cache (for testing).
+ */
+export function resetTrustScoreCache(): void {
+  for (const key of Object.keys(trustScoreCache)) {
+    delete trustScoreCache[key];
+  }
+}

--- a/tests/unit/gate-persistence.test.ts
+++ b/tests/unit/gate-persistence.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit Tests — src/gate-persistence.ts (S35)
+ *
+ * Tests for gate evaluation persistence, double-loop learning,
+ * and corrective instruction generation.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  generateDoubleLoopInstruction,
+  type DimensionWeakness,
+} from "../../src/gate-persistence";
+
+// ── generateDoubleLoopInstruction ─────────────────────────────
+
+describe("generateDoubleLoopInstruction", () => {
+  it("generates instruction for error_handling dimension", () => {
+    const instruction = generateDoubleLoopInstruction("dev", "error_handling", 4);
+    expect(instruction).toContain("gestion d'erreurs");
+    expect(instruction).toContain("4 evaluations");
+    expect(instruction).toContain("ALERTE QUALITE");
+  });
+
+  it("generates instruction for test_coverage dimension", () => {
+    const instruction = generateDoubleLoopInstruction("dev", "test_coverage", 3);
+    expect(instruction).toContain("couverture de tests");
+    expect(instruction).toContain("3 evaluations");
+  });
+
+  it("generates instruction for code_style dimension", () => {
+    const instruction = generateDoubleLoopInstruction("dev", "code_style", 5);
+    expect(instruction).toContain("style de code");
+  });
+
+  it("generates instruction for spec_conformity dimension", () => {
+    const instruction = generateDoubleLoopInstruction("dev", "spec_conformity", 3);
+    expect(instruction).toContain("spec");
+  });
+
+  it("generates instruction for completeness dimension", () => {
+    const instruction = generateDoubleLoopInstruction("pm", "completeness", 4);
+    expect(instruction).toContain("completude");
+  });
+
+  it("generates instruction for traceability dimension", () => {
+    const instruction = generateDoubleLoopInstruction("pm", "traceability", 3);
+    expect(instruction).toContain("tracabilite");
+  });
+
+  it("generates instruction for clarity dimension", () => {
+    const instruction = generateDoubleLoopInstruction("architect", "clarity", 3);
+    expect(instruction).toContain("clarte");
+  });
+
+  it("generates instruction for feasibility dimension", () => {
+    const instruction = generateDoubleLoopInstruction("architect", "feasibility", 5);
+    expect(instruction).toContain("faisabilite");
+  });
+
+  it("generates generic instruction for unknown dimension", () => {
+    const instruction = generateDoubleLoopInstruction("dev", "unknown_dim", 3);
+    expect(instruction).toContain("unknown_dim");
+    expect(instruction).toContain("ALERTE QUALITE");
+    expect(instruction).toContain("3 evaluations");
+  });
+
+  it("includes weakness count in all instructions", () => {
+    const dims = ["error_handling", "test_coverage", "code_style", "spec_conformity",
+      "completeness", "traceability", "clarity", "feasibility"];
+    for (const dim of dims) {
+      const instruction = generateDoubleLoopInstruction("dev", dim, 7);
+      expect(instruction).toContain("7 evaluations");
+    }
+  });
+});
+
+// ── DimensionWeakness type ───────────────────────────────────
+
+describe("DimensionWeakness type", () => {
+  it("has the expected shape", () => {
+    const weakness: DimensionWeakness = {
+      agentRole: "dev",
+      dimensionName: "error_handling",
+      count: 3,
+    };
+    expect(weakness.agentRole).toBe("dev");
+    expect(weakness.dimensionName).toBe("error_handling");
+    expect(weakness.count).toBe(3);
+  });
+});

--- a/tests/unit/trust-integration.test.ts
+++ b/tests/unit/trust-integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit Tests — Trust Score + Gate Evaluator Integration (S35)
+ *
+ * Tests for evaluateAndRework trust score updates,
+ * auto-approval logic, and double-loop feedback context.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  evaluateAndRework,
+  type GateEvaluation,
+} from "../../src/gate-evaluator";
+import {
+  getCachedTrustScore,
+  resetTrustScoreCache,
+  updateTrustScore,
+  shouldAutoApprove,
+} from "../../src/trust-scores";
+import { buildFeedbackContext } from "../../src/feedback-loop";
+
+beforeEach(() => {
+  resetTrustScoreCache();
+});
+
+// ── evaluateAndRework trust score updates ─────────────────────
+
+describe("evaluateAndRework with trust scores", () => {
+  it("updates trust score on pass without rework (AC-010)", async () => {
+    const result = await evaluateAndRework(
+      null,
+      "session-trust-1",
+      "dev",
+      "implementation",
+      { code: "good" },
+      async () => ({ code: "reworked" }),
+      {
+        maxIterations: 2,
+        customEvaluator: async () => ({
+          pass: true, score: 85, issues: [], gate_name: "implementation",
+        }),
+      }
+    );
+
+    expect(result.finalEvaluation.pass).toBe(true);
+    expect(result.passedAtIteration).toBe(0);
+
+    // Wait a tick for async trust update
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const trust = getCachedTrustScore("dev");
+    expect(trust.score).toBe(55); // 50 + 5
+    expect(trust.consecutivePasses).toBe(1);
+  });
+
+  it("updates trust score on pass with rework", async () => {
+    let evalCount = 0;
+    const result = await evaluateAndRework(
+      null,
+      "session-trust-2",
+      "pm",
+      "tasks",
+      { tasks: [] },
+      async () => ({ tasks: ["reworked"] }),
+      {
+        maxIterations: 2,
+        customEvaluator: async () => {
+          evalCount++;
+          if (evalCount === 1) {
+            return { pass: false, score: 40, issues: [{ severity: "major", description: "Bad", suggestion: "Fix" }], gate_name: "tasks" };
+          }
+          return { pass: true, score: 75, issues: [], gate_name: "tasks" };
+        },
+      }
+    );
+
+    expect(result.finalEvaluation.pass).toBe(true);
+    expect(result.passedAtIteration).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const trust = getCachedTrustScore("pm");
+    expect(trust.score).toBe(51); // 50 + 1 (pass with rework)
+  });
+
+  it("updates trust score on failure after max rework", async () => {
+    const result = await evaluateAndRework(
+      null,
+      "session-trust-3",
+      "architect",
+      "plan",
+      { plan: "bad" },
+      async () => ({ plan: "still bad" }),
+      {
+        maxIterations: 1,
+        customEvaluator: async () => ({
+          pass: false, score: 30, issues: [{ severity: "critical", description: "Poor", suggestion: "Redo" }], gate_name: "plan",
+        }),
+      }
+    );
+
+    expect(result.finalEvaluation.pass).toBe(false);
+    expect(result.passedAtIteration).toBeNull();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const trust = getCachedTrustScore("architect");
+    expect(trust.score).toBe(40); // 50 - 10
+    expect(trust.consecutiveFailures).toBe(1);
+  });
+
+  it("preserves backward compatibility with number maxIterations", async () => {
+    const result = await evaluateAndRework(
+      null,
+      "session-compat",
+      "qa",
+      "spec",
+      { spec: "ok" },
+      async () => ({ spec: "reworked" }),
+      2, // legacy number format
+      async () => ({ pass: true, score: 80, issues: [], gate_name: "spec" }) // legacy customEvaluator
+    );
+
+    expect(result.finalEvaluation.pass).toBe(true);
+  });
+});
+
+// ── Auto-approval flow ───────────────────────────────────────
+
+describe("auto-approval trust score progression", () => {
+  it("builds trust from 50 to 80 over consecutive passes", async () => {
+    // 6 consecutive passes: 50 + 6*5 = 80
+    for (let i = 0; i < 6; i++) {
+      await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    const trust = getCachedTrustScore("dev");
+    expect(trust.score).toBe(80);
+    expect(trust.consecutivePasses).toBe(6);
+
+    // Spec gate should be auto-approvable for P3
+    expect(shouldAutoApprove("dev", "spec", 3)).toBe(true);
+    // But not implementation (needs 90)
+    expect(shouldAutoApprove("dev", "implementation", 3)).toBe(false);
+  });
+
+  it("builds trust from 50 to 90 over consecutive passes", async () => {
+    // 8 consecutive passes: 50 + 8*5 = 90
+    for (let i = 0; i < 8; i++) {
+      await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    expect(getCachedTrustScore("dev").score).toBe(90);
+
+    // Implementation gate should now be auto-approvable for P3
+    expect(shouldAutoApprove("dev", "implementation", 3)).toBe(true);
+  });
+
+  it("drops trust on failure, disabling auto-approval", async () => {
+    // Build to 80
+    for (let i = 0; i < 6; i++) {
+      await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    expect(shouldAutoApprove("dev", "spec", 3)).toBe(true);
+
+    // One failure: 80 - 10 = 70
+    await updateTrustScore(null, "dev", { passed: false, hadRework: true });
+    expect(getCachedTrustScore("dev").score).toBe(70);
+    expect(shouldAutoApprove("dev", "spec", 3)).toBe(false);
+  });
+});
+
+// ── Feedback context with double-loop rules ──────────────────
+
+describe("buildFeedbackContext with double-loop rules", () => {
+  it("returns empty string when no rules (baseline)", () => {
+    expect(buildFeedbackContext("dev" as any)).toBe("");
+  });
+});

--- a/tests/unit/trust-scores.test.ts
+++ b/tests/unit/trust-scores.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit Tests — src/trust-scores.ts (S35)
+ *
+ * Tests for trust score calculation, auto-approval logic,
+ * and formatting.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  updateTrustScore,
+  getCachedTrustScore,
+  getCachedTrustScores,
+  shouldAutoApprove,
+  formatTrustScores,
+  resetTrustScoreCache,
+  AUTO_APPROVE_SPEC_THRESHOLD,
+  AUTO_APPROVE_IMPL_THRESHOLD,
+  AUTO_APPROVE_MAX_PRIORITY,
+} from "../../src/trust-scores";
+
+beforeEach(() => {
+  resetTrustScoreCache();
+});
+
+// ── Trust Score Defaults ─────────────────────────────────────
+
+describe("getCachedTrustScore", () => {
+  it("returns default score of 50 for unknown role (AC-009)", () => {
+    const score = getCachedTrustScore("dev");
+    expect(score.score).toBe(50);
+    expect(score.consecutivePasses).toBe(0);
+    expect(score.consecutiveFailures).toBe(0);
+    expect(score.totalEvaluations).toBe(0);
+    expect(score.totalPasses).toBe(0);
+  });
+});
+
+// ── updateTrustScore ─────────────────────────────────────────
+
+describe("updateTrustScore", () => {
+  it("increases score by 5 on pass without rework", async () => {
+    const result = await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    expect(result.score).toBe(55); // 50 + 5
+    expect(result.consecutivePasses).toBe(1);
+    expect(result.consecutiveFailures).toBe(0);
+    expect(result.totalEvaluations).toBe(1);
+    expect(result.totalPasses).toBe(1);
+  });
+
+  it("increases score by 1 on pass with rework", async () => {
+    const result = await updateTrustScore(null, "dev", { passed: true, hadRework: true });
+    expect(result.score).toBe(51); // 50 + 1
+  });
+
+  it("decreases score by 10 on failure", async () => {
+    const result = await updateTrustScore(null, "dev", { passed: false, hadRework: true });
+    expect(result.score).toBe(40); // 50 - 10
+    expect(result.consecutivePasses).toBe(0);
+    expect(result.consecutiveFailures).toBe(1);
+  });
+
+  it("caps score at 100 (AC-007)", async () => {
+    // Push score to 95
+    for (let i = 0; i < 9; i++) {
+      await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    const high = getCachedTrustScore("dev");
+    expect(high.score).toBe(95);
+
+    // One more should cap at 100
+    const result = await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    expect(result.score).toBe(100);
+  });
+
+  it("floors score at 0 (AC-007)", async () => {
+    // Push score down
+    for (let i = 0; i < 5; i++) {
+      await updateTrustScore(null, "dev", { passed: false, hadRework: true });
+    }
+    const result = getCachedTrustScore("dev");
+    expect(result.score).toBe(0); // 50 - 50 = 0
+  });
+
+  it("resets consecutive passes on failure (AC-008)", async () => {
+    await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    expect(getCachedTrustScore("dev").consecutivePasses).toBe(2);
+
+    await updateTrustScore(null, "dev", { passed: false, hadRework: true });
+    expect(getCachedTrustScore("dev").consecutivePasses).toBe(0);
+    expect(getCachedTrustScore("dev").consecutiveFailures).toBe(1);
+  });
+
+  it("resets consecutive failures on pass", async () => {
+    await updateTrustScore(null, "dev", { passed: false, hadRework: true });
+    await updateTrustScore(null, "dev", { passed: false, hadRework: true });
+    expect(getCachedTrustScore("dev").consecutiveFailures).toBe(2);
+
+    await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    expect(getCachedTrustScore("dev").consecutiveFailures).toBe(0);
+    expect(getCachedTrustScore("dev").consecutivePasses).toBe(1);
+  });
+
+  it("tracks total evaluations and passes", async () => {
+    await updateTrustScore(null, "qa", { passed: true, hadRework: false });
+    await updateTrustScore(null, "qa", { passed: false, hadRework: true });
+    await updateTrustScore(null, "qa", { passed: true, hadRework: true });
+
+    const result = getCachedTrustScore("qa");
+    expect(result.totalEvaluations).toBe(3);
+    expect(result.totalPasses).toBe(2);
+  });
+
+  it("handles multiple roles independently", async () => {
+    await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    await updateTrustScore(null, "pm", { passed: false, hadRework: true });
+
+    expect(getCachedTrustScore("dev").score).toBe(55);
+    expect(getCachedTrustScore("pm").score).toBe(40);
+  });
+});
+
+// ── shouldAutoApprove ────────────────────────────────────────
+
+describe("shouldAutoApprove", () => {
+  it("returns false for P1 tasks regardless of trust score (AC-019)", () => {
+    // Set dev trust to 95
+    resetTrustScoreCache();
+    for (let i = 0; i < 9; i++) {
+      updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    expect(shouldAutoApprove("dev", "spec", 1)).toBe(false);
+    expect(shouldAutoApprove("dev", "implementation", 1)).toBe(false);
+  });
+
+  it("returns false for P2 tasks regardless of trust score", () => {
+    resetTrustScoreCache();
+    for (let i = 0; i < 9; i++) {
+      updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    expect(shouldAutoApprove("dev", "plan", 2)).toBe(false);
+  });
+
+  it("returns true for spec gate with trust >= 80 and P3+", async () => {
+    // Push trust to 80: 50 + 6*5 = 80
+    for (let i = 0; i < 6; i++) {
+      await updateTrustScore(null, "pm", { passed: true, hadRework: false });
+    }
+    expect(shouldAutoApprove("pm", "spec", 3)).toBe(true);
+    expect(shouldAutoApprove("pm", "plan", 4)).toBe(true);
+    expect(shouldAutoApprove("pm", "tasks", 5)).toBe(true);
+  });
+
+  it("returns false for spec gate with trust < 80", async () => {
+    // Score = 55
+    await updateTrustScore(null, "pm", { passed: true, hadRework: false });
+    expect(shouldAutoApprove("pm", "spec", 3)).toBe(false);
+  });
+
+  it("returns true for implementation gate with trust >= 90 and P3+ (AC-018)", async () => {
+    // Push trust to 90: 50 + 8*5 = 90
+    for (let i = 0; i < 8; i++) {
+      await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    expect(shouldAutoApprove("dev", "implementation", 3)).toBe(true);
+  });
+
+  it("returns false for implementation gate with trust 80 (needs 90)", async () => {
+    // Push trust to 80
+    for (let i = 0; i < 6; i++) {
+      await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    }
+    expect(shouldAutoApprove("dev", "implementation", 3)).toBe(false);
+  });
+
+  it("returns false for unknown role (default score 50)", () => {
+    expect(shouldAutoApprove("unknown", "spec", 3)).toBe(false);
+  });
+});
+
+// ── formatTrustScores ────────────────────────────────────────
+
+describe("formatTrustScores", () => {
+  it("returns fallback message when no data", () => {
+    expect(formatTrustScores()).toBe("Pas de donnees de confiance");
+  });
+
+  it("formats trust scores with stats", async () => {
+    await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    await updateTrustScore(null, "pm", { passed: false, hadRework: true });
+
+    const formatted = formatTrustScores();
+    expect(formatted).toContain("Trust scores par role:");
+    expect(formatted).toContain("dev: 55/100");
+    expect(formatted).toContain("pm: 40/100");
+  });
+});
+
+// ── getCachedTrustScores ─────────────────────────────────────
+
+describe("getCachedTrustScores", () => {
+  it("returns copy of all cached scores", async () => {
+    await updateTrustScore(null, "dev", { passed: true, hadRework: false });
+    await updateTrustScore(null, "qa", { passed: true, hadRework: false });
+
+    const scores = getCachedTrustScores();
+    expect(Object.keys(scores)).toContain("dev");
+    expect(Object.keys(scores)).toContain("qa");
+    expect(scores.dev.score).toBe(55);
+  });
+});


### PR DESCRIPTION
## Summary
- Gate evaluation results persisted to `gate_evaluations` table (rubric dimensions, deterministic checks, rework iteration)
- Trust scores per agent role in `trust_scores` table: +5 pass, +1 rework pass, -10 fail (0-100 range)
- Double-loop learning: rubric dimension weak 3+ times auto-generates corrective feedback rules
- Progressive auto-approval: trust >= 80 skips LLM on spec/plan gates (P3+), trust >= 90 on implementation gates
- /monitor extended with trust scores, recent evaluations, and active double-loop rules
- Feature flag `auto_gate_approval` (disabled by default)
- 39 new tests (948 total, 0 fail)

## Test plan
- [x] Trust score calculation: +5/-10/+1 deltas, 0-100 bounds, consecutive tracking
- [x] Auto-approval: P1/P2 never auto-approved, thresholds 80/90
- [x] evaluateAndRework integration: trust updates on pass/fail/rework
- [x] Double-loop instruction generation for all 8 rubric dimensions
- [x] Backward compatibility: number maxIterations still works
- [x] Full test suite: 948 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)