### PR TITLE
Créer formatDocumentContext dans bot-context.ts

### DIFF
--- a/config/heartbeat-state.json
+++ b/config/heartbeat-state.json
@@ -1,22 +1,12 @@
 {
-  "lastPulseAt": "2026-03-19T10:10:00.118Z",
-  "lastCommitSha": "4add62658bea84b4ed76c5c881045aaf19e34f33",
+  "lastPulseAt": "2026-03-19T10:30:00.129Z",
+  "lastCommitSha": "9a06e818130047f0e485a3052641f62b2c5affc7",
   "lastSprintSnapshot": {
     "sprint": null,
     "done": 0,
     "total": 0
   },
   "recentActions": [
-    {
-      "type": "none",
-      "summary": "Rien a signaler",
-      "timestamp": "2026-03-19T08:40:13.620Z"
-    },
-    {
-      "type": "none",
-      "summary": "Rien a signaler",
-      "timestamp": "2026-03-19T08:50:18.405Z"
-    },
     {
       "type": "notify",
       "summary": "⚠️ PR #13 (Fix path traversal in document handler) bloquée depuis 24 jours. C'est une fix de sécurité — à merger ou à archiver ?",
@@ -56,6 +46,16 @@
       "type": "task_create",
       "summary": "Investigate PR #13 estimate and status",
       "timestamp": "2026-03-19T10:10:13.858Z"
+    },
+    {
+      "type": "none",
+      "summary": "Rien a signaler",
+      "timestamp": "2026-03-19T10:20:13.326Z"
+    },
+    {
+      "type": "none",
+      "summary": "Rien a signaler",
+      "timestamp": "2026-03-19T10:30:17.341Z"
     }
   ],
   "cooldowns": {},

--- a/src/bot-context.ts
+++ b/src/bot-context.ts
@@ -15,6 +15,7 @@ import { synthesize } from "./tts.ts";
 import { analyzeProfile } from "./profile-evolution.ts";
 import { getTopicConfig as getTopicConfigHelper, type TopicConfig } from "./topic-config.ts";
 import { getIdea } from "./memory.ts";
+import type { DocumentSearchResult } from "./documents.ts";
 
 // ============================================================
 // CONFIG CONSTANTS
@@ -83,6 +84,7 @@ export interface BotContext {
     recentMessages?: string,
     topicName?: string,
     dynamicProfile?: string,
+    documentContext?: string,
   ) => string;
   saveMessage: (role: string, content: string, metadata?: Record<string, unknown>) => Promise<void>;
   getDynamicProfile: () => Promise<string>;
@@ -441,6 +443,42 @@ async function getDynamicProfile(): Promise<string> {
 }
 
 // ============================================================
+// DOCUMENT CONTEXT FORMATTER
+// ============================================================
+
+/**
+ * Formats an array of DocumentSearchResult into a string for prompt injection.
+ * Pure function — no side effects, no network calls.
+ */
+export function formatDocumentContext(results: DocumentSearchResult[]): string {
+  if (results.length === 0) return "";
+
+  const lines: string[] = ["--- DOCUMENTS PERTINENTS ---"];
+
+  for (let i = 0; i < results.length; i++) {
+    const doc = results[i];
+    const title = doc.title || "Document sans titre";
+    const category = doc.category_id ? `cat: ${doc.category_id}` : "";
+    const date = doc.document_date || "date inconnue";
+    const score = Math.round(doc.similarity * 100);
+
+    let summary = "";
+    if (doc.extracted_text) {
+      summary =
+        doc.extracted_text.length > 200
+          ? doc.extracted_text.substring(0, 200) + "..."
+          : doc.extracted_text;
+    }
+
+    const meta = [category, date, `pertinence: ${score}%`].filter(Boolean).join(", ");
+    lines.push(`[${i + 1}] ${title} (${meta})`);
+    if (summary) lines.push(`    ${summary}`);
+  }
+
+  return lines.join("\n");
+}
+
+// ============================================================
 // PROMPT BUILDER
 // ============================================================
 
@@ -451,6 +489,7 @@ function buildPrompt(
   recentMessages?: string,
   topicName?: string,
   dynamicProfile?: string,
+  documentContext?: string,
 ): string {
   const now = new Date();
   const timeStr = now.toLocaleString("en-US", {
@@ -484,6 +523,7 @@ function buildPrompt(
   if (profileContext) parts.push(`\nProfile:\n${profileContext}`);
   if (dynamicProfile) parts.push(dynamicProfile);
   if (memoryContext) parts.push(`\n${memoryContext}`);
+  if (documentContext) parts.push(`\n${documentContext}`);
   if (relevantContext) parts.push(`\n${relevantContext}`);
 
   parts.push(

--- a/tests/unit/format-document-context.test.ts
+++ b/tests/unit/format-document-context.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "bun:test";
+import { formatDocumentContext } from "../../src/bot-context.ts";
+import type { DocumentSearchResult } from "../../src/documents.ts";
+
+describe("formatDocumentContext", () => {
+  it("returns empty string for empty array (AC-1)", () => {
+    expect(formatDocumentContext([])).toBe("");
+  });
+
+  it("formats 3 documents with header, numbering, title, category_id, date, score%, summary (AC-2)", () => {
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-1",
+        title: "Facture EDF",
+        extracted_text: "Montant total: 127.50 EUR",
+        description: null,
+        document_date: "2026-01-15",
+        category_id: "a1b2c3d4",
+        created_at: "2026-01-15T10:00:00Z",
+        similarity: 0.87,
+        file_path: "docs/facture.pdf",
+      },
+      {
+        id: "doc-2",
+        title: "Contrat de bail",
+        extracted_text: "Bail de 3 ans pour le logement situe au 12 rue de la Paix",
+        description: null,
+        document_date: "2025-06-01",
+        category_id: "e5f6g7h8",
+        created_at: "2025-06-01T08:00:00Z",
+        similarity: 0.72,
+        file_path: "docs/bail.pdf",
+      },
+      {
+        id: "doc-3",
+        title: "Ordonnance medicale",
+        extracted_text: "Prescription de paracetamol 1000mg",
+        description: null,
+        document_date: "2026-03-10",
+        category_id: "i9j0k1l2",
+        created_at: "2026-03-10T14:30:00Z",
+        similarity: 0.55,
+        file_path: "docs/ordo.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+
+    expect(result).toContain("--- DOCUMENTS PERTINENTS ---");
+    expect(result).toContain("[1] Facture EDF");
+    expect(result).toContain("[2] Contrat de bail");
+    expect(result).toContain("[3] Ordonnance medicale");
+    expect(result).toContain("cat: a1b2c3d4");
+    expect(result).toContain("2026-01-15");
+    expect(result).toContain("pertinence: 87%");
+    expect(result).toContain("pertinence: 72%");
+    expect(result).toContain("pertinence: 55%");
+    expect(result).toContain("Montant total: 127.50 EUR");
+  });
+
+  it("truncates extracted_text to 200 chars with '...' (AC-3)", () => {
+    const longText = "A".repeat(500);
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-long",
+        title: "Long document",
+        extracted_text: longText,
+        description: null,
+        document_date: "2026-01-01",
+        category_id: null,
+        created_at: "2026-01-01T00:00:00Z",
+        similarity: 0.9,
+        file_path: "docs/long.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+    const summaryLine = result.split("\n").find((l) => l.startsWith("    "))!;
+    const summary = summaryLine.trim();
+
+    // 200 chars + "..." = 203 chars max
+    expect(summary.length).toBeLessThanOrEqual(203);
+    expect(summary).toEndWith("...");
+    expect(summary).toBe("A".repeat(200) + "...");
+  });
+
+  it("does not add '...' when text is <= 200 chars", () => {
+    const shortText = "Short content here";
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-short",
+        title: "Short doc",
+        extracted_text: shortText,
+        description: null,
+        document_date: "2026-02-01",
+        category_id: "cat-1",
+        created_at: "2026-02-01T00:00:00Z",
+        similarity: 0.65,
+        file_path: "docs/short.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+    expect(result).toContain(shortText);
+    expect(result).not.toContain("...");
+  });
+
+  it("handles null title with fallback", () => {
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-notitle",
+        title: null,
+        extracted_text: "Some content",
+        description: null,
+        document_date: "2026-01-01",
+        category_id: null,
+        created_at: "2026-01-01T00:00:00Z",
+        similarity: 0.8,
+        file_path: "docs/notitle.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+    expect(result).toContain("Document sans titre");
+  });
+
+  it("handles null document_date with fallback", () => {
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-nodate",
+        title: "No date doc",
+        extracted_text: "Content",
+        description: null,
+        document_date: null,
+        category_id: null,
+        created_at: "2026-01-01T00:00:00Z",
+        similarity: 0.6,
+        file_path: "docs/nodate.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+    expect(result).toContain("date inconnue");
+  });
+
+  it("handles null extracted_text gracefully", () => {
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-notext",
+        title: "No text doc",
+        extracted_text: null,
+        description: null,
+        document_date: "2026-01-01",
+        category_id: "cat-1",
+        created_at: "2026-01-01T00:00:00Z",
+        similarity: 0.75,
+        file_path: "docs/notext.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+    expect(result).toContain("[1] No text doc");
+    // No summary line for null extracted_text
+    const lines = result.split("\n");
+    const summaryLines = lines.filter((l) => l.startsWith("    "));
+    expect(summaryLines.length).toBe(0);
+  });
+
+  it("omits category when category_id is null", () => {
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-nocat",
+        title: "No category",
+        extracted_text: "Content",
+        description: null,
+        document_date: "2026-01-01",
+        category_id: null,
+        created_at: "2026-01-01T00:00:00Z",
+        similarity: 0.5,
+        file_path: "docs/nocat.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+    expect(result).not.toContain("cat:");
+    expect(result).toContain("2026-01-01");
+  });
+
+  it("rounds similarity correctly", () => {
+    const results: DocumentSearchResult[] = [
+      {
+        id: "doc-round",
+        title: "Rounding test",
+        extracted_text: "Content",
+        description: null,
+        document_date: "2026-01-01",
+        category_id: null,
+        created_at: "2026-01-01T00:00:00Z",
+        similarity: 0.876,
+        file_path: "docs/round.pdf",
+      },
+    ];
+
+    const result = formatDocumentContext(results);
+    expect(result).toContain("pertinence: 88%");
+  });
+});


### PR DESCRIPTION
Tache automatisee via /exec

ID: d9f858d4
Priorite: P1

Fonction helper qui prend un tableau de résultats searchDocuments et retourne une string formatée pour injection dans le prompt. Tronque extracted_text à 200 chars, affiche titre, catégorie, date, score de pertinence en pourcentage. Retourne string vide si tableau vide.