### PR TITLE
Ajouter le paramètre documentContext à buildPrompt

### DIFF
--- a/config/heartbeat-state.json
+++ b/config/heartbeat-state.json
@@ -1,22 +1,12 @@
 {
-  "lastPulseAt": "2026-03-19T10:30:00.129Z",
-  "lastCommitSha": "9a06e818130047f0e485a3052641f62b2c5affc7",
+  "lastPulseAt": "2026-03-19T10:50:00.125Z",
+  "lastCommitSha": "7cc5802f2e5f417b7f963ffb7d4b85a659bbdc7d",
   "lastSprintSnapshot": {
     "sprint": null,
     "done": 0,
     "total": 0
   },
   "recentActions": [
-    {
-      "type": "notify",
-      "summary": "⚠️ PR #13 (Fix path traversal in document handler) bloquée depuis 24 jours. C'est une fix de sécurité — à merger ou à archiver ?",
-      "timestamp": "2026-03-19T09:00:22.392Z"
-    },
-    {
-      "type": "none",
-      "summary": "Rien a signaler",
-      "timestamp": "2026-03-19T09:10:14.699Z"
-    },
     {
       "type": "none",
       "summary": "Rien a signaler",
@@ -56,10 +46,20 @@
       "type": "none",
       "summary": "Rien a signaler",
       "timestamp": "2026-03-19T10:30:17.341Z"
+    },
+    {
+      "type": "none",
+      "summary": "Rien a signaler",
+      "timestamp": "2026-03-19T10:40:16.975Z"
+    },
+    {
+      "type": "none",
+      "summary": "Rien a signaler",
+      "timestamp": "2026-03-19T10:50:17.083Z"
     }
   ],
   "cooldowns": {},
-  "lastAlertCheckAt": "2026-03-19T09:40:00.117Z",
-  "lastArchivalAt": "2026-03-19T09:40:00.117Z",
+  "lastAlertCheckAt": "2026-03-19T10:40:00.126Z",
+  "lastArchivalAt": "2026-03-19T10:40:00.126Z",
   "lastAutonomyScanAt": "2026-03-18T18:30:00.124Z"
 }

--- a/src/bot-context.ts
+++ b/src/bot-context.ts
@@ -523,7 +523,10 @@ function buildPrompt(
   if (profileContext) parts.push(`\nProfile:\n${profileContext}`);
   if (dynamicProfile) parts.push(dynamicProfile);
   if (memoryContext) parts.push(`\n${memoryContext}`);
-  if (documentContext) parts.push(`\n${documentContext}`);
+  if (documentContext) {
+    parts.push(`\n${documentContext}`);
+    parts.push("Si des documents pertinents sont listés ci-dessus, tu peux les mentionner naturellement dans ta réponse quand c'est utile. Ne force pas leur mention si le sujet n'est pas lié.");
+  }
   if (relevantContext) parts.push(`\n${relevantContext}`);
 
   parts.push(

--- a/tests/unit/bot-context.test.ts
+++ b/tests/unit/bot-context.test.ts
@@ -219,6 +219,29 @@ describe("bot-context", () => {
       }
       // The prompt builder checks USER_NAME — always passes since it is conditional
     });
+
+    it("includes document context and system instruction when documentContext is non-empty", () => {
+      const docCtx = "DOCUMENTS PERTINENTS:\n- Facture EDF (facture, 0.85)";
+      const prompt = botCtx.buildPrompt("test", undefined, undefined, undefined, undefined, undefined, docCtx);
+      expect(prompt).toContain(docCtx);
+      expect(prompt).toContain("Si des documents pertinents sont listés ci-dessus, tu peux les mentionner naturellement dans ta réponse quand c'est utile. Ne force pas leur mention si le sujet n'est pas lié.");
+      // Instruction appears before MEMORY MANAGEMENT
+      const instrIdx = prompt.indexOf("Ne force pas leur mention");
+      const memMgmtIdx = prompt.indexOf("MEMORY MANAGEMENT");
+      expect(instrIdx).toBeLessThan(memMgmtIdx);
+    });
+
+    it("excludes document section and instruction when documentContext is undefined", () => {
+      const prompt = botCtx.buildPrompt("test", undefined, undefined, undefined, undefined, undefined, undefined);
+      expect(prompt).not.toContain("DOCUMENTS PERTINENTS");
+      expect(prompt).not.toContain("Ne force pas leur mention");
+    });
+
+    it("excludes document section and instruction when documentContext is empty string", () => {
+      const prompt = botCtx.buildPrompt("test", undefined, undefined, undefined, undefined, undefined, "");
+      expect(prompt).not.toContain("DOCUMENTS PERTINENTS");
+      expect(prompt).not.toContain("Ne force pas leur mention");
+    });
   });
 
   // ── sendResponse ───────────────────────────────────────


### PR DESCRIPTION
Tache automatisee via /exec

ID: ae5fd98e
Priorite: P1

Étendre la signature de buildPrompt dans bot-context.ts avec un paramètre optionnel documentContext?: string. Insérer la section documents entre le contexte mémoire et les instructions mémoire dans le template de prompt. Ajouter l'instruction système : 'Si des documents pertinents sont listés ci-dessus, tu peux les mentionner naturellement dans ta réponse quand c'est utile. Ne force pas leur mention si le sujet n'est pas lié.'