### PR TITLE
Creer config/audit.json avec poids, seuils et regles de layering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `cost-tracking.ts` | Token usage tracking, multi-model cost estimation (Opus/Sonnet/Haiku), sprint cost aggregation, /cost command |
 | `workflow.ts` | Workflow engine: loads config/workflow.yaml, tracks state transitions, transition enforcement, retry policies |
 | `alerts.ts` | Anomaly detection: stuck tasks, rework spikes, schedule slips |
+| `audit.ts` | Audit configuration loader and validator: reads config/audit.json, validates weights/thresholds/layering, provides layering violation detection |
 | `patterns.ts` | Multi-sprint pattern analysis, workflow improvement proposals |
 | `prd.ts` | PRD management: draft → approved/rejected |
 | `prd-workflow.ts` | Conversational PRD-to-Deploy workflow: triage, generation with session constraints, bounded revision (max 3), auto-decomposition, implementation launch, gate notifications, PR merge |

--- a/config/audit.json
+++ b/config/audit.json
@@ -1,0 +1,73 @@
+{
+  "weights": {
+    "structure": 20,
+    "tests": 20,
+    "architecture": 20,
+    "debt": 15,
+    "security": 15,
+    "docs": 10
+  },
+  "globalThresholds": {
+    "pass": 70,
+    "warn": 50
+  },
+  "axisThresholds": {
+    "structure": {
+      "maxLineCount": 1000,
+      "maxComplexity": 8
+    },
+    "tests": {
+      "minCoveragePercent": 80
+    },
+    "debt": {
+      "todoMaxAgeDays": 60
+    },
+    "architecture": {
+      "maxDependencyCount": 10
+    },
+    "security": {
+      "maxAnyCount": 5
+    }
+  },
+  "penalties": {
+    "structure": {
+      "largeModule": 10,
+      "highComplexity": 5,
+      "emptyExports": 1
+    },
+    "debt": {
+      "critical": 5,
+      "important": 3,
+      "minor": 1
+    },
+    "architecture": {
+      "cycle": 20,
+      "overCoupled": 5
+    },
+    "security": {
+      "important": 3,
+      "minor": 1
+    }
+  },
+  "layering": [
+    {
+      "source": "src/commands/",
+      "forbiddenTargets": ["db/"],
+      "message": "Composers must not import database layer directly — use bot-context or service modules"
+    },
+    {
+      "source": "mcp/",
+      "forbiddenTargets": ["src/commands/"],
+      "message": "MCP server must not import Telegram command handlers"
+    },
+    {
+      "source": "supabase/functions/",
+      "forbiddenTargets": ["src/"],
+      "message": "Edge Functions are deployed independently — must not import source modules"
+    }
+  ],
+  "fix": {
+    "defaultPriority": 2,
+    "tag": "audit"
+  }
+}

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -1,0 +1,380 @@
+/**
+ * @module audit
+ * @description Audit configuration loader and validator. Reads config/audit.json,
+ * validates structure (weights sum 100%, correct types), and provides layering
+ * violation detection against the code graph.
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import type { CodeGraph, GraphEdge } from "./code-graph.ts";
+
+const PROJECT_ROOT = process.env.PROJECT_DIR || process.cwd();
+const CONFIG_PATH = join(PROJECT_ROOT, "config", "audit.json");
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface AuditWeights {
+  structure: number;
+  tests: number;
+  architecture: number;
+  debt: number;
+  security: number;
+  docs: number;
+}
+
+export interface GlobalThresholds {
+  pass: number;
+  warn: number;
+}
+
+export interface StructureThresholds {
+  maxLineCount: number;
+  maxComplexity: number;
+}
+
+export interface TestsThresholds {
+  minCoveragePercent: number;
+}
+
+export interface DebtThresholds {
+  todoMaxAgeDays: number;
+}
+
+export interface ArchitectureThresholds {
+  maxDependencyCount: number;
+}
+
+export interface SecurityThresholds {
+  maxAnyCount: number;
+}
+
+export interface AxisThresholds {
+  structure: StructureThresholds;
+  tests: TestsThresholds;
+  debt: DebtThresholds;
+  architecture: ArchitectureThresholds;
+  security: SecurityThresholds;
+}
+
+export interface StructurePenalties {
+  largeModule: number;
+  highComplexity: number;
+  emptyExports: number;
+}
+
+export interface DebtPenalties {
+  critical: number;
+  important: number;
+  minor: number;
+}
+
+export interface ArchitecturePenalties {
+  cycle: number;
+  overCoupled: number;
+}
+
+export interface SecurityPenalties {
+  important: number;
+  minor: number;
+}
+
+export interface Penalties {
+  structure: StructurePenalties;
+  debt: DebtPenalties;
+  architecture: ArchitecturePenalties;
+  security: SecurityPenalties;
+}
+
+export interface LayeringRule {
+  source: string;
+  forbiddenTargets: string[];
+  message: string;
+}
+
+export interface FixConfig {
+  defaultPriority: number;
+  tag: string;
+}
+
+export interface AuditConfig {
+  weights: AuditWeights;
+  globalThresholds: GlobalThresholds;
+  axisThresholds: AxisThresholds;
+  penalties: Penalties;
+  layering: LayeringRule[];
+  fix: FixConfig;
+}
+
+export interface AuditFinding {
+  axis: string;
+  severity: "warning" | "critical";
+  message: string;
+  file?: string;
+  detail?: string;
+}
+
+// ── Defaults ─────────────────────────────────────────────────
+
+const DEFAULT_WEIGHTS: AuditWeights = {
+  structure: 20,
+  tests: 20,
+  architecture: 20,
+  debt: 15,
+  security: 15,
+  docs: 10,
+};
+
+const DEFAULT_GLOBAL_THRESHOLDS: GlobalThresholds = {
+  pass: 70,
+  warn: 50,
+};
+
+const DEFAULT_AXIS_THRESHOLDS: AxisThresholds = {
+  structure: { maxLineCount: 500, maxComplexity: 8 },
+  tests: { minCoveragePercent: 80 },
+  debt: { todoMaxAgeDays: 60 },
+  architecture: { maxDependencyCount: 10 },
+  security: { maxAnyCount: 5 },
+};
+
+const DEFAULT_PENALTIES: Penalties = {
+  structure: { largeModule: 10, highComplexity: 5, emptyExports: 1 },
+  debt: { critical: 5, important: 3, minor: 1 },
+  architecture: { cycle: 20, overCoupled: 5 },
+  security: { important: 3, minor: 1 },
+};
+
+const DEFAULT_FIX: FixConfig = {
+  defaultPriority: 2,
+  tag: "audit",
+};
+
+const WEIGHT_AXES = ["structure", "tests", "architecture", "debt", "security", "docs"] as const;
+
+// ── Validation ───────────────────────────────────────────────
+
+/**
+ * Validate that the audit config has correct structure and types.
+ * Throws on invalid config.
+ */
+export function validateAuditConfig(config: unknown): asserts config is AuditConfig {
+  if (typeof config !== "object" || config === null) {
+    throw new Error("Audit config must be a non-null object");
+  }
+
+  const obj = config as Record<string, unknown>;
+
+  // Validate weights
+  if (typeof obj.weights !== "object" || obj.weights === null) {
+    throw new Error("Audit config: 'weights' must be an object");
+  }
+  const weights = obj.weights as Record<string, unknown>;
+  for (const axis of WEIGHT_AXES) {
+    if (typeof weights[axis] !== "number" || weights[axis] < 0) {
+      throw new Error(`Audit config: weights.${axis} must be a non-negative number`);
+    }
+  }
+  const weightSum = WEIGHT_AXES.reduce((sum, axis) => sum + (weights[axis] as number), 0);
+  if (weightSum !== 100) {
+    throw new Error(`Audit config: weights must total 100%, got ${weightSum}%`);
+  }
+
+  // Validate globalThresholds
+  if (typeof obj.globalThresholds !== "object" || obj.globalThresholds === null) {
+    throw new Error("Audit config: 'globalThresholds' must be an object");
+  }
+  const gt = obj.globalThresholds as Record<string, unknown>;
+  if (typeof gt.pass !== "number") throw new Error("Audit config: globalThresholds.pass must be a number");
+  if (typeof gt.warn !== "number") throw new Error("Audit config: globalThresholds.warn must be a number");
+
+  // Validate axisThresholds
+  if (typeof obj.axisThresholds !== "object" || obj.axisThresholds === null) {
+    throw new Error("Audit config: 'axisThresholds' must be an object");
+  }
+  const at = obj.axisThresholds as Record<string, unknown>;
+  validateNumberField(at, "structure", "maxLineCount");
+  validateNumberField(at, "structure", "maxComplexity");
+  validateNumberField(at, "tests", "minCoveragePercent");
+  validateNumberField(at, "debt", "todoMaxAgeDays");
+  validateNumberField(at, "architecture", "maxDependencyCount");
+  validateNumberField(at, "security", "maxAnyCount");
+
+  // Validate penalties
+  if (typeof obj.penalties !== "object" || obj.penalties === null) {
+    throw new Error("Audit config: 'penalties' must be an object");
+  }
+
+  // Validate layering
+  if (!Array.isArray(obj.layering)) {
+    throw new Error("Audit config: 'layering' must be an array");
+  }
+  for (let i = 0; i < obj.layering.length; i++) {
+    const rule = obj.layering[i];
+    if (typeof rule !== "object" || rule === null) {
+      throw new Error(`Audit config: layering[${i}] must be an object`);
+    }
+    if (typeof rule.source !== "string") {
+      throw new Error(`Audit config: layering[${i}].source must be a string`);
+    }
+    if (!Array.isArray(rule.forbiddenTargets) || !rule.forbiddenTargets.every((t: unknown) => typeof t === "string")) {
+      throw new Error(`Audit config: layering[${i}].forbiddenTargets must be a string array`);
+    }
+    if (typeof rule.message !== "string") {
+      throw new Error(`Audit config: layering[${i}].message must be a string`);
+    }
+  }
+
+  // Validate fix
+  if (typeof obj.fix !== "object" || obj.fix === null) {
+    throw new Error("Audit config: 'fix' must be an object");
+  }
+  const fix = obj.fix as Record<string, unknown>;
+  if (typeof fix.defaultPriority !== "number") throw new Error("Audit config: fix.defaultPriority must be a number");
+  if (typeof fix.tag !== "string") throw new Error("Audit config: fix.tag must be a string");
+}
+
+function validateNumberField(parent: Record<string, unknown>, section: string, field: string): void {
+  const sectionObj = parent[section] as Record<string, unknown> | undefined;
+  if (typeof sectionObj !== "object" || sectionObj === null) {
+    throw new Error(`Audit config: axisThresholds.${section} must be an object`);
+  }
+  if (typeof sectionObj[field] !== "number") {
+    throw new Error(`Audit config: axisThresholds.${section}.${field} must be a number`);
+  }
+}
+
+// ── Loader ───────────────────────────────────────────────────
+
+let configCache: AuditConfig | null = null;
+
+/**
+ * Load and validate audit config from config/audit.json.
+ * Returns validated AuditConfig. Caches result in memory.
+ * @param configPath Override path for testing
+ */
+export function loadAuditConfig(configPath?: string): AuditConfig {
+  if (configCache && !configPath) return configCache;
+
+  const path = configPath || CONFIG_PATH;
+
+  if (!existsSync(path)) {
+    const defaultConfig = buildDefaultConfig();
+    if (!configPath) configCache = defaultConfig;
+    return defaultConfig;
+  }
+
+  const raw = readFileSync(path, "utf-8");
+  const parsed = JSON.parse(raw);
+
+  validateAuditConfig(parsed);
+
+  if (!configPath) configCache = parsed;
+  return parsed;
+}
+
+/**
+ * Build a default config (all defaults, weights sum 100%).
+ */
+export function buildDefaultConfig(): AuditConfig {
+  return {
+    weights: { ...DEFAULT_WEIGHTS },
+    globalThresholds: { ...DEFAULT_GLOBAL_THRESHOLDS },
+    axisThresholds: JSON.parse(JSON.stringify(DEFAULT_AXIS_THRESHOLDS)),
+    penalties: JSON.parse(JSON.stringify(DEFAULT_PENALTIES)),
+    layering: [],
+    fix: { ...DEFAULT_FIX },
+  };
+}
+
+/**
+ * Clear the config cache (for testing).
+ */
+export function clearAuditConfigCache(): void {
+  configCache = null;
+}
+
+// ── Threshold helpers ────────────────────────────────────────
+
+/**
+ * Get axis thresholds with fallback to defaults.
+ */
+export function getAxisThresholds(config: AuditConfig): AxisThresholds {
+  return {
+    structure: {
+      maxLineCount: config.axisThresholds?.structure?.maxLineCount ?? DEFAULT_AXIS_THRESHOLDS.structure.maxLineCount,
+      maxComplexity: config.axisThresholds?.structure?.maxComplexity ?? DEFAULT_AXIS_THRESHOLDS.structure.maxComplexity,
+    },
+    tests: {
+      minCoveragePercent: config.axisThresholds?.tests?.minCoveragePercent ?? DEFAULT_AXIS_THRESHOLDS.tests.minCoveragePercent,
+    },
+    debt: {
+      todoMaxAgeDays: config.axisThresholds?.debt?.todoMaxAgeDays ?? DEFAULT_AXIS_THRESHOLDS.debt.todoMaxAgeDays,
+    },
+    architecture: {
+      maxDependencyCount: config.axisThresholds?.architecture?.maxDependencyCount ?? DEFAULT_AXIS_THRESHOLDS.architecture.maxDependencyCount,
+    },
+    security: {
+      maxAnyCount: config.axisThresholds?.security?.maxAnyCount ?? DEFAULT_AXIS_THRESHOLDS.security.maxAnyCount,
+    },
+  };
+}
+
+/**
+ * Get penalties with fallback to defaults.
+ */
+export function getPenalties(config: AuditConfig): Penalties {
+  return {
+    structure: {
+      largeModule: config.penalties?.structure?.largeModule ?? DEFAULT_PENALTIES.structure.largeModule,
+      highComplexity: config.penalties?.structure?.highComplexity ?? DEFAULT_PENALTIES.structure.highComplexity,
+      emptyExports: config.penalties?.structure?.emptyExports ?? DEFAULT_PENALTIES.structure.emptyExports,
+    },
+    debt: {
+      critical: config.penalties?.debt?.critical ?? DEFAULT_PENALTIES.debt.critical,
+      important: config.penalties?.debt?.important ?? DEFAULT_PENALTIES.debt.important,
+      minor: config.penalties?.debt?.minor ?? DEFAULT_PENALTIES.debt.minor,
+    },
+    architecture: {
+      cycle: config.penalties?.architecture?.cycle ?? DEFAULT_PENALTIES.architecture.cycle,
+      overCoupled: config.penalties?.architecture?.overCoupled ?? DEFAULT_PENALTIES.architecture.overCoupled,
+    },
+    security: {
+      important: config.penalties?.security?.important ?? DEFAULT_PENALTIES.security.important,
+      minor: config.penalties?.security?.minor ?? DEFAULT_PENALTIES.security.minor,
+    },
+  };
+}
+
+// ── Layering check ───────────────────────────────────────────
+
+/**
+ * Check code graph edges against layering rules.
+ * Returns AuditFinding for each violation detected.
+ */
+export function checkLayeringViolations(
+  graph: CodeGraph,
+  rules: LayeringRule[]
+): AuditFinding[] {
+  const findings: AuditFinding[] = [];
+
+  for (const edge of graph.edges) {
+    for (const rule of rules) {
+      if (!edge.source.startsWith(rule.source)) continue;
+
+      for (const forbidden of rule.forbiddenTargets) {
+        if (edge.target.startsWith(forbidden)) {
+          findings.push({
+            axis: "architecture",
+            severity: "critical",
+            message: rule.message,
+            file: edge.source,
+            detail: `${edge.source} -> ${edge.target} violates layering: ${rule.source} must not import ${forbidden}`,
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}

--- a/tests/unit/audit.test.ts
+++ b/tests/unit/audit.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Tests for audit config loader and validator.
+ * Covers AC-1 (weights sum 100%), AC-2 (layering violations),
+ * AC-3 (custom thresholds), AC-4 (JSON structure validation).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import {
+  loadAuditConfig,
+  validateAuditConfig,
+  buildDefaultConfig,
+  clearAuditConfigCache,
+  checkLayeringViolations,
+  getAxisThresholds,
+  getPenalties,
+  type AuditConfig,
+  type AuditFinding,
+  type LayeringRule,
+} from "../../src/audit.ts";
+import type { CodeGraph } from "../../src/code-graph.ts";
+
+const TMP_DIR = join(process.cwd(), "tests", "tmp");
+const TMP_CONFIG = join(TMP_DIR, "audit-test.json");
+
+function writeTestConfig(config: unknown): string {
+  if (!existsSync(TMP_DIR)) mkdirSync(TMP_DIR, { recursive: true });
+  writeFileSync(TMP_CONFIG, JSON.stringify(config, null, 2), "utf-8");
+  return TMP_CONFIG;
+}
+
+function cleanupTestConfig(): void {
+  if (existsSync(TMP_CONFIG)) unlinkSync(TMP_CONFIG);
+}
+
+function validConfig(): AuditConfig {
+  return {
+    weights: { structure: 20, tests: 20, architecture: 20, debt: 15, security: 15, docs: 10 },
+    globalThresholds: { pass: 70, warn: 50 },
+    axisThresholds: {
+      structure: { maxLineCount: 1000, maxComplexity: 8 },
+      tests: { minCoveragePercent: 80 },
+      debt: { todoMaxAgeDays: 60 },
+      architecture: { maxDependencyCount: 10 },
+      security: { maxAnyCount: 5 },
+    },
+    penalties: {
+      structure: { largeModule: 10, highComplexity: 5, emptyExports: 1 },
+      debt: { critical: 5, important: 3, minor: 1 },
+      architecture: { cycle: 20, overCoupled: 5 },
+      security: { important: 3, minor: 1 },
+    },
+    layering: [
+      {
+        source: "src/commands/",
+        forbiddenTargets: ["db/"],
+        message: "Composers must not import database layer directly",
+      },
+    ],
+    fix: { defaultPriority: 2, tag: "audit" },
+  };
+}
+
+function makeGraph(edges: Array<{ source: string; target: string }>): CodeGraph {
+  return {
+    nodes: [],
+    edges: edges.map((e) => ({
+      source: e.source,
+      target: e.target,
+      imports: [],
+      isTypeOnly: false,
+    })),
+    indexedAt: new Date().toISOString(),
+  };
+}
+
+beforeEach(() => {
+  clearAuditConfigCache();
+});
+
+afterEach(() => {
+  cleanupTestConfig();
+  clearAuditConfigCache();
+});
+
+// ── AC-1: Weights total 100% ────────────────────────────────
+
+describe("AC-1: weights total 100%", () => {
+  it("accepts config where weights sum to 100", () => {
+    const config = validConfig();
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+    const sum = Object.values(loaded.weights).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(100);
+  });
+
+  it("rejects config where weights sum to 90", () => {
+    const config = validConfig();
+    config.weights.docs = 0; // 20+20+20+15+15+0 = 90
+    const path = writeTestConfig(config);
+    expect(() => loadAuditConfig(path)).toThrow("weights must total 100%");
+  });
+
+  it("rejects config where weights sum to 110", () => {
+    const config = validConfig();
+    config.weights.docs = 20; // 20+20+20+15+15+20 = 110
+    const path = writeTestConfig(config);
+    expect(() => loadAuditConfig(path)).toThrow("weights must total 100%");
+  });
+
+  it("loads default config with weights summing to 100 when file missing", () => {
+    const loaded = loadAuditConfig(join(TMP_DIR, "nonexistent.json"));
+    const sum = Object.values(loaded.weights).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(100);
+  });
+
+  it("validates all 6 axis keys are present in weights", () => {
+    const config = validConfig();
+    expect(config.weights).toHaveProperty("structure");
+    expect(config.weights).toHaveProperty("tests");
+    expect(config.weights).toHaveProperty("architecture");
+    expect(config.weights).toHaveProperty("debt");
+    expect(config.weights).toHaveProperty("security");
+    expect(config.weights).toHaveProperty("docs");
+  });
+
+  it("loads the actual config/audit.json and weights sum to 100", () => {
+    clearAuditConfigCache();
+    const loaded = loadAuditConfig();
+    const sum = Object.values(loaded.weights).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(100);
+  });
+});
+
+// ── AC-2: Layering violations ────────────────────────────────
+
+describe("AC-2: layering violation detection", () => {
+  it("detects commands/ -> db/ violation", () => {
+    const rules: LayeringRule[] = [
+      {
+        source: "src/commands/",
+        forbiddenTargets: ["db/"],
+        message: "Composers must not import database layer directly",
+      },
+    ];
+    const graph = makeGraph([
+      { source: "src/commands/tasks.ts", target: "db/schema.ts" },
+    ]);
+
+    const findings = checkLayeringViolations(graph, rules);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].axis).toBe("architecture");
+    expect(findings[0].severity).toBe("critical");
+    expect(findings[0].message).toBe("Composers must not import database layer directly");
+    expect(findings[0].file).toBe("src/commands/tasks.ts");
+    expect(findings[0].detail).toContain("src/commands/tasks.ts -> db/schema.ts");
+  });
+
+  it("does not flag valid imports from commands/", () => {
+    const rules: LayeringRule[] = [
+      {
+        source: "src/commands/",
+        forbiddenTargets: ["db/"],
+        message: "Composers must not import database layer directly",
+      },
+    ];
+    const graph = makeGraph([
+      { source: "src/commands/tasks.ts", target: "src/tasks.ts" },
+    ]);
+
+    const findings = checkLayeringViolations(graph, rules);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not flag edges from non-matching sources", () => {
+    const rules: LayeringRule[] = [
+      {
+        source: "src/commands/",
+        forbiddenTargets: ["db/"],
+        message: "test",
+      },
+    ];
+    const graph = makeGraph([
+      { source: "src/orchestrator.ts", target: "db/schema.ts" },
+    ]);
+
+    const findings = checkLayeringViolations(graph, rules);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("detects multiple violations in a single graph", () => {
+    const rules: LayeringRule[] = [
+      {
+        source: "src/commands/",
+        forbiddenTargets: ["db/"],
+        message: "No DB from commands",
+      },
+      {
+        source: "mcp/",
+        forbiddenTargets: ["src/commands/"],
+        message: "MCP must not import commands",
+      },
+    ];
+    const graph = makeGraph([
+      { source: "src/commands/audit.ts", target: "db/migrations.ts" },
+      { source: "mcp/memory-server.ts", target: "src/commands/help.ts" },
+    ]);
+
+    const findings = checkLayeringViolations(graph, rules);
+    expect(findings).toHaveLength(2);
+    expect(findings[0].message).toBe("No DB from commands");
+    expect(findings[1].message).toBe("MCP must not import commands");
+  });
+
+  it("detects violation for multiple forbidden targets in one rule", () => {
+    const rules: LayeringRule[] = [
+      {
+        source: "supabase/functions/",
+        forbiddenTargets: ["src/"],
+        message: "Edge Functions must not import source modules",
+      },
+    ];
+    const graph = makeGraph([
+      { source: "supabase/functions/embed/index.ts", target: "src/memory.ts" },
+    ]);
+
+    const findings = checkLayeringViolations(graph, rules);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toBe("Edge Functions must not import source modules");
+  });
+
+  it("returns empty findings for empty rules", () => {
+    const graph = makeGraph([
+      { source: "src/commands/tasks.ts", target: "db/schema.ts" },
+    ]);
+    const findings = checkLayeringViolations(graph, []);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("returns empty findings for empty graph", () => {
+    const rules: LayeringRule[] = [
+      { source: "src/commands/", forbiddenTargets: ["db/"], message: "test" },
+    ];
+    const findings = checkLayeringViolations({ nodes: [], edges: [], indexedAt: "" }, rules);
+    expect(findings).toHaveLength(0);
+  });
+
+  it("uses layering rules from loaded config", () => {
+    const config = validConfig();
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+    const graph = makeGraph([
+      { source: "src/commands/tasks.ts", target: "db/schema.ts" },
+    ]);
+
+    const findings = checkLayeringViolations(graph, loaded.layering);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toBe("Composers must not import database layer directly");
+  });
+});
+
+// ── AC-3: Custom thresholds override defaults ────────────────
+
+describe("AC-3: custom thresholds", () => {
+  it("uses custom maxLineCount from config", () => {
+    const config = validConfig();
+    config.axisThresholds.structure.maxLineCount = 800;
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+    const thresholds = getAxisThresholds(loaded);
+
+    // 750 lines < 800 threshold = no warning
+    expect(750 < thresholds.structure.maxLineCount).toBe(true);
+  });
+
+  it("default maxLineCount is 500 in buildDefaultConfig", () => {
+    const defaults = buildDefaultConfig();
+    const thresholds = getAxisThresholds(defaults);
+    expect(thresholds.structure.maxLineCount).toBe(500);
+  });
+
+  it("config maxLineCount=1000 overrides default 500", () => {
+    const config = validConfig();
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+    expect(loaded.axisThresholds.structure.maxLineCount).toBe(1000);
+  });
+
+  it("750-line module passes with 800 threshold, would fail with 500 default", () => {
+    const config = validConfig();
+    config.axisThresholds.structure.maxLineCount = 800;
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+
+    const moduleLineCount = 750;
+    const customThreshold = loaded.axisThresholds.structure.maxLineCount;
+    const defaultThreshold = 500;
+
+    expect(moduleLineCount < customThreshold).toBe(true); // no warning with custom
+    expect(moduleLineCount >= defaultThreshold).toBe(true); // would warn with default
+  });
+
+  it("custom minCoveragePercent overrides default", () => {
+    const config = validConfig();
+    config.axisThresholds.tests.minCoveragePercent = 90;
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+    expect(loaded.axisThresholds.tests.minCoveragePercent).toBe(90);
+  });
+
+  it("custom maxDependencyCount overrides default", () => {
+    const config = validConfig();
+    config.axisThresholds.architecture.maxDependencyCount = 15;
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+    expect(loaded.axisThresholds.architecture.maxDependencyCount).toBe(15);
+  });
+
+  it("custom penalties override defaults", () => {
+    const config = validConfig();
+    config.penalties.structure.largeModule = 15;
+    const path = writeTestConfig(config);
+    const loaded = loadAuditConfig(path);
+    const penalties = getPenalties(loaded);
+    expect(penalties.structure.largeModule).toBe(15);
+  });
+
+  it("getAxisThresholds returns all sections", () => {
+    const config = validConfig();
+    const thresholds = getAxisThresholds(config);
+    expect(thresholds.structure).toBeDefined();
+    expect(thresholds.tests).toBeDefined();
+    expect(thresholds.debt).toBeDefined();
+    expect(thresholds.architecture).toBeDefined();
+    expect(thresholds.security).toBeDefined();
+  });
+
+  it("getPenalties returns all sections", () => {
+    const config = validConfig();
+    const penalties = getPenalties(config);
+    expect(penalties.structure).toBeDefined();
+    expect(penalties.debt).toBeDefined();
+    expect(penalties.architecture).toBeDefined();
+    expect(penalties.security).toBeDefined();
+  });
+});
+
+// ── AC-4: JSON structure validation ──────────────────────────
+
+describe("AC-4: JSON structure validation", () => {
+  it("accepts valid config", () => {
+    const config = validConfig();
+    expect(() => validateAuditConfig(config)).not.toThrow();
+  });
+
+  it("rejects null", () => {
+    expect(() => validateAuditConfig(null)).toThrow("non-null object");
+  });
+
+  it("rejects string", () => {
+    expect(() => validateAuditConfig("not an object")).toThrow("non-null object");
+  });
+
+  it("rejects missing weights", () => {
+    const config = validConfig() as Record<string, unknown>;
+    delete config.weights;
+    expect(() => validateAuditConfig(config)).toThrow("weights");
+  });
+
+  it("rejects non-numeric weight", () => {
+    const config = validConfig();
+    (config.weights as any).structure = "twenty";
+    expect(() => validateAuditConfig(config)).toThrow("weights.structure must be a non-negative number");
+  });
+
+  it("rejects negative weight", () => {
+    const config = validConfig();
+    config.weights.structure = -5;
+    expect(() => validateAuditConfig(config)).toThrow("weights.structure must be a non-negative number");
+  });
+
+  it("rejects missing globalThresholds", () => {
+    const config = validConfig() as Record<string, unknown>;
+    delete config.globalThresholds;
+    expect(() => validateAuditConfig(config)).toThrow("globalThresholds");
+  });
+
+  it("rejects non-numeric globalThresholds.pass", () => {
+    const config = validConfig();
+    (config.globalThresholds as any).pass = "high";
+    expect(() => validateAuditConfig(config)).toThrow("globalThresholds.pass must be a number");
+  });
+
+  it("rejects missing axisThresholds", () => {
+    const config = validConfig() as Record<string, unknown>;
+    delete config.axisThresholds;
+    expect(() => validateAuditConfig(config)).toThrow("axisThresholds");
+  });
+
+  it("rejects non-numeric axisThresholds.structure.maxLineCount", () => {
+    const config = validConfig();
+    (config.axisThresholds.structure as any).maxLineCount = "big";
+    expect(() => validateAuditConfig(config)).toThrow("axisThresholds.structure.maxLineCount must be a number");
+  });
+
+  it("rejects missing penalties", () => {
+    const config = validConfig() as Record<string, unknown>;
+    delete config.penalties;
+    expect(() => validateAuditConfig(config)).toThrow("penalties");
+  });
+
+  it("rejects non-array layering", () => {
+    const config = validConfig();
+    (config as any).layering = "not an array";
+    expect(() => validateAuditConfig(config)).toThrow("layering");
+  });
+
+  it("rejects layering rule with missing source", () => {
+    const config = validConfig();
+    config.layering = [{ forbiddenTargets: ["db/"], message: "test" } as any];
+    expect(() => validateAuditConfig(config)).toThrow("layering[0].source must be a string");
+  });
+
+  it("rejects layering rule with non-array forbiddenTargets", () => {
+    const config = validConfig();
+    config.layering = [{ source: "src/", forbiddenTargets: "db/", message: "test" } as any];
+    expect(() => validateAuditConfig(config)).toThrow("layering[0].forbiddenTargets must be a string array");
+  });
+
+  it("rejects layering rule with non-string in forbiddenTargets", () => {
+    const config = validConfig();
+    config.layering = [{ source: "src/", forbiddenTargets: [42], message: "test" } as any];
+    expect(() => validateAuditConfig(config)).toThrow("layering[0].forbiddenTargets must be a string array");
+  });
+
+  it("rejects layering rule with missing message", () => {
+    const config = validConfig();
+    config.layering = [{ source: "src/", forbiddenTargets: ["db/"] } as any];
+    expect(() => validateAuditConfig(config)).toThrow("layering[0].message must be a string");
+  });
+
+  it("rejects missing fix", () => {
+    const config = validConfig() as Record<string, unknown>;
+    delete config.fix;
+    expect(() => validateAuditConfig(config)).toThrow("fix");
+  });
+
+  it("rejects non-numeric fix.defaultPriority", () => {
+    const config = validConfig();
+    (config.fix as any).defaultPriority = "high";
+    expect(() => validateAuditConfig(config)).toThrow("fix.defaultPriority must be a number");
+  });
+
+  it("rejects non-string fix.tag", () => {
+    const config = validConfig();
+    (config.fix as any).tag = 123;
+    expect(() => validateAuditConfig(config)).toThrow("fix.tag must be a string");
+  });
+
+  it("accepts empty layering array", () => {
+    const config = validConfig();
+    config.layering = [];
+    expect(() => validateAuditConfig(config)).not.toThrow();
+  });
+
+  it("validates all field types in the actual config/audit.json", () => {
+    clearAuditConfigCache();
+    const loaded = loadAuditConfig();
+    expect(() => validateAuditConfig(loaded)).not.toThrow();
+    expect(typeof loaded.weights.structure).toBe("number");
+    expect(typeof loaded.globalThresholds.pass).toBe("number");
+    expect(typeof loaded.axisThresholds.structure.maxLineCount).toBe("number");
+    expect(typeof loaded.penalties.structure.largeModule).toBe("number");
+    expect(Array.isArray(loaded.layering)).toBe(true);
+    expect(typeof loaded.fix.tag).toBe("string");
+  });
+});
+
+// ── Config loading edge cases ────────────────────────────────
+
+describe("config loading", () => {
+  it("caches config after first load", () => {
+    const config = validConfig();
+    const path = writeTestConfig(config);
+    const first = loadAuditConfig(path);
+    const second = loadAuditConfig(path);
+    expect(first).toEqual(second);
+  });
+
+  it("clearAuditConfigCache forces reload", () => {
+    const config = validConfig();
+    const path = writeTestConfig(config);
+    loadAuditConfig(path);
+    clearAuditConfigCache();
+    // Modify the file
+    config.axisThresholds.structure.maxLineCount = 2000;
+    writeTestConfig(config);
+    const reloaded = loadAuditConfig(path);
+    expect(reloaded.axisThresholds.structure.maxLineCount).toBe(2000);
+  });
+
+  it("returns default config when file does not exist", () => {
+    const loaded = loadAuditConfig(join(TMP_DIR, "nonexistent.json"));
+    expect(loaded.weights).toEqual({ structure: 20, tests: 20, architecture: 20, debt: 15, security: 15, docs: 10 });
+  });
+
+  it("buildDefaultConfig weights sum to 100", () => {
+    const defaults = buildDefaultConfig();
+    const sum = Object.values(defaults.weights).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(100);
+  });
+
+  it("throws on invalid JSON syntax", () => {
+    if (!existsSync(TMP_DIR)) mkdirSync(TMP_DIR, { recursive: true });
+    writeFileSync(TMP_CONFIG, "{ invalid json }", "utf-8");
+    expect(() => loadAuditConfig(TMP_CONFIG)).toThrow();
+  });
+});


### PR DESCRIPTION
Tache automatisee via /exec

ID: 40f891c2
Priorite: P2

Fichier de configuration JSON definissant les poids des 6 axes, les seuils warning/critical par metrique taille fichier, complexite, etc., et les regles de layering architecture ex: commands/ ne doit pas importer depuis db/. Tous les seuils hardcodes dans audit-axes.ts doivent etre lus depuis ce fichier.