### PR TITLE
Integrer l'audit leger dans heartbeat.ts

### DIFF
--- a/config/features.json
+++ b/config/features.json
@@ -1,5 +1,6 @@
 {
   "model_cascade": false,
+  "audit_system": false,
   "heartbeat": true,
   "explore_mode": true,
   "job_manager": true,

--- a/src/heartbeat-prompt.ts
+++ b/src/heartbeat-prompt.ts
@@ -19,6 +19,9 @@ export interface HeartbeatState {
   lastAlertCheckAt: string | null;    // when alerts were last run (hourly)
   lastArchivalAt: string | null;      // when memory archival last ran (hourly)
   lastAutonomyScanAt: string | null;  // when autonomy scan last ran (daily)
+  // Lightweight audit tracking (daily)
+  lastAuditAt: string | null;         // when lightweight audit last ran (daily)
+  lastAuditScore: number | null;      // last audit score (0-100)
 }
 
 export interface HeartbeatAction {
@@ -216,5 +219,7 @@ export function createDefaultState(): HeartbeatState {
     lastAlertCheckAt: null,
     lastArchivalAt: null,
     lastAutonomyScanAt: null,
+    lastAuditAt: null,
+    lastAuditScore: null,
   };
 }

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -47,6 +47,16 @@ import { archiveOldMemories } from "./memory.ts";
 import { loadPrefs, isQuietHours } from "./notification-prefs.ts";
 import { loadQueue, getQueue, flushMorningDigest, enqueue } from "./notification-queue.ts";
 import { runAllScanners, isDuplicate } from "./autonomy-scanner.ts";
+import {
+  extractModules,
+  extractCommands,
+  parseClaudeMdModules,
+  parseClaudeMdCommands,
+  parseClaudeMdTestCount,
+  countTests,
+  findGaps,
+  type DocState,
+} from "../scripts/doc-utils.ts";
 
 const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 const RELAY_DIR = process.env.RELAY_DIR || join(process.env.HOME || "~", ".claude-relay");
@@ -346,6 +356,79 @@ export async function executeActions(
   return executed;
 }
 
+// ── Lightweight Audit ─────────────────────────────────────────
+
+export interface LightweightAuditResult {
+  score: number;
+  gaps: Array<{ type: string; item: string; detail: string }>;
+  testCount: number;
+}
+
+/**
+ * Compute audit score from gaps list.
+ * Score: 100 - (5 * missing/extra modules) - (5 * missing/extra commands) - (10 if test count drifts).
+ * Clamped to [0, 100].
+ */
+export function computeAuditScore(gaps: Array<{ type: string }>): number {
+  let score = 100;
+  for (const gap of gaps) {
+    score -= gap.type === "test_count" ? 10 : 5;
+  }
+  return Math.max(0, Math.min(100, score));
+}
+
+/**
+ * Run a lightweight structure + tests audit using doc-utils.
+ */
+export async function runLightweightAudit(projectDir: string): Promise<LightweightAuditResult> {
+  const srcDir = join(projectDir, "src");
+  const relayPath = join(srcDir, "relay.ts");
+  const claudeMdPath = join(projectDir, "CLAUDE.md");
+  const testsDir = join(projectDir, "tests");
+
+  const srcModules = await extractModules(srcDir);
+  const srcCommands = await extractCommands(relayPath);
+  const claudeMdModules = await parseClaudeMdModules(claudeMdPath);
+  const claudeMdCommands = await parseClaudeMdCommands(claudeMdPath);
+
+  const claudeMdContent = await readFile(claudeMdPath, "utf-8");
+  const claudeMdTestCount = parseClaudeMdTestCount(claudeMdContent);
+
+  // Only run countTests if structural checks pass (avoid heavy operation)
+  let actualTestCount = claudeMdTestCount; // assume no drift by default
+  const structState: DocState = {
+    srcModules,
+    claudeMdModules,
+    srcCommands,
+    claudeMdCommands,
+    actualTestCount,
+    claudeMdTestCount,
+  };
+  const structGaps = findGaps(structState);
+  const structuralGapsOnly = structGaps.filter(g => g.type !== "test_count");
+
+  if (structuralGapsOnly.length === 0) {
+    try {
+      actualTestCount = await countTests(testsDir);
+    } catch {
+      actualTestCount = claudeMdTestCount; // fallback: assume no drift
+    }
+  }
+
+  const fullState: DocState = {
+    srcModules,
+    claudeMdModules,
+    srcCommands,
+    claudeMdCommands,
+    actualTestCount,
+    claudeMdTestCount,
+  };
+  const gaps = findGaps(fullState);
+  const score = computeAuditScore(gaps);
+
+  return { score, gaps, testCount: actualTestCount };
+}
+
 // ── Main Pulse ────────────────────────────────────────────────
 
 export async function pulse(): Promise<{
@@ -576,6 +659,44 @@ export async function pulse(): Promise<{
     }
   } catch (err) {
     console.error(`[${timestamp}] Autonomy scan error:`, err);
+  }
+
+  // Daily: Lightweight audit (structure + tests)
+  try {
+    const dayAgo = now - 24 * 60 * 60 * 1000;
+    if (
+      isFeatureEnabled("audit_system") &&
+      (!state.lastAuditAt || new Date(state.lastAuditAt).getTime() < dayAgo)
+    ) {
+      console.log(`[${timestamp}] Running daily lightweight audit...`);
+      const auditResult = await runLightweightAudit(PROJECT_DIR);
+      console.log(`[${timestamp}] Audit score: ${auditResult.score}/100 (${auditResult.gaps.length} gap(s))`);
+
+      // Check for regression (only if we have a previous score)
+      if (
+        state.lastAuditScore !== null &&
+        state.lastAuditScore - auditResult.score > 5
+      ) {
+        const delta = state.lastAuditScore - auditResult.score;
+        await writeMcpPending({
+          type: "alert",
+          severity: "normal",
+          message: `[Audit] Score structure/tests en regression: ${state.lastAuditScore} -> ${auditResult.score} (${delta} points). ${auditResult.gaps.length} ecart(s) detecte(s).`,
+          data: {
+            previousScore: state.lastAuditScore,
+            currentScore: auditResult.score,
+            delta,
+            gapCount: auditResult.gaps.length,
+          },
+        });
+        console.log(`[${timestamp}] Audit regression alert sent: ${state.lastAuditScore} -> ${auditResult.score}`);
+      }
+
+      state.lastAuditAt = timestamp;
+      state.lastAuditScore = auditResult.score;
+    }
+  } catch (err) {
+    console.error(`[${timestamp}] Lightweight audit error:`, err);
   }
 
   // ── Save state and return ─────────────────────────────────

--- a/tests/unit/heartbeat.test.ts
+++ b/tests/unit/heartbeat.test.ts
@@ -377,6 +377,201 @@ describe("Heartbeat Actions", () => {
   });
 });
 
+// ── Lightweight Audit ─────────────────────────────────────
+
+describe("computeAuditScore", () => {
+  it("should return 100 when no gaps", async () => {
+    const { computeAuditScore } = await import("../../src/heartbeat");
+    expect(computeAuditScore([])).toBe(100);
+  });
+
+  it("should deduct 5 points per module gap", async () => {
+    const { computeAuditScore } = await import("../../src/heartbeat");
+    const gaps = [
+      { type: "missing_module" },
+      { type: "extra_module" },
+    ];
+    expect(computeAuditScore(gaps)).toBe(90);
+  });
+
+  it("should deduct 5 points per command gap", async () => {
+    const { computeAuditScore } = await import("../../src/heartbeat");
+    const gaps = [
+      { type: "missing_command" },
+      { type: "extra_command" },
+    ];
+    expect(computeAuditScore(gaps)).toBe(90);
+  });
+
+  it("should deduct 10 points for test count gap", async () => {
+    const { computeAuditScore } = await import("../../src/heartbeat");
+    const gaps = [{ type: "test_count" }];
+    expect(computeAuditScore(gaps)).toBe(90);
+  });
+
+  it("should clamp score to 0 minimum", async () => {
+    const { computeAuditScore } = await import("../../src/heartbeat");
+    // 25 module gaps = 125 point deduction
+    const gaps = Array.from({ length: 25 }, () => ({ type: "missing_module" }));
+    expect(computeAuditScore(gaps)).toBe(0);
+  });
+
+  it("should handle mixed gap types", async () => {
+    const { computeAuditScore } = await import("../../src/heartbeat");
+    const gaps = [
+      { type: "missing_module" },   // -5
+      { type: "extra_command" },     // -5
+      { type: "test_count" },        // -10
+    ];
+    expect(computeAuditScore(gaps)).toBe(80);
+  });
+});
+
+describe("Heartbeat Lightweight Audit Integration", () => {
+  // AC-1: Given heartbeat active + audit_system enabled + 24h elapsed → audit is triggered
+  describe("AC-1: Daily audit trigger", () => {
+    it("should trigger audit when audit_system enabled and 24h elapsed", async () => {
+      // We test the time-gating logic by checking state changes
+      const state = createDefaultState();
+      state.lastAuditAt = null; // never run before
+
+      const dayAgo = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+      const now = Date.now();
+      const isExpired = !state.lastAuditAt || new Date(state.lastAuditAt).getTime() < (now - 24 * 60 * 60 * 1000);
+      expect(isExpired).toBe(true);
+    });
+
+    it("should not trigger audit when less than 24h elapsed", () => {
+      const state = createDefaultState();
+      state.lastAuditAt = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString(); // 12h ago
+
+      const now = Date.now();
+      const dayAgo = now - 24 * 60 * 60 * 1000;
+      const isExpired = !state.lastAuditAt || new Date(state.lastAuditAt).getTime() < dayAgo;
+      expect(isExpired).toBe(false);
+    });
+
+    it("should trigger audit on first run (lastAuditAt null)", () => {
+      const state = createDefaultState();
+      expect(state.lastAuditAt).toBeNull();
+
+      const now = Date.now();
+      const dayAgo = now - 24 * 60 * 60 * 1000;
+      const isExpired = !state.lastAuditAt || new Date(state.lastAuditAt).getTime() < dayAgo;
+      expect(isExpired).toBe(true);
+    });
+  });
+
+  // AC-2: Score regression > 5 points → alert via notification
+  describe("AC-2: Regression alert", () => {
+    it("should detect regression when score drops by more than 5 points", () => {
+      const previousScore = 78;
+      const currentScore = 72;
+      const delta = previousScore - currentScore;
+      const shouldAlert = previousScore !== null && delta > 5;
+      expect(shouldAlert).toBe(true);
+      expect(delta).toBe(6);
+    });
+
+    it("should include delta in alert message", () => {
+      const previousScore = 78;
+      const currentScore = 72;
+      const delta = previousScore - currentScore;
+      const message = `[Audit] Score structure/tests en regression: ${previousScore} -> ${currentScore} (${delta} points). 3 ecart(s) detecte(s).`;
+      expect(message).toContain("78 -> 72");
+      expect(message).toContain("6 points");
+      expect(message).toContain("3 ecart(s)");
+    });
+
+    it("should detect large regression (e.g. 20 points)", () => {
+      const previousScore = 90;
+      const currentScore = 70;
+      const delta = previousScore - currentScore;
+      expect(delta > 5).toBe(true);
+      expect(delta).toBe(20);
+    });
+  });
+
+  // AC-3: Stable score (delta <= 5) → no alert
+  describe("AC-3: No alert on stable score", () => {
+    it("should not alert when score improves", () => {
+      const previousScore = 72;
+      const currentScore = 78;
+      const delta = previousScore - currentScore;
+      const shouldAlert = previousScore !== null && delta > 5;
+      expect(shouldAlert).toBe(false);
+    });
+
+    it("should not alert when score is exactly 5 points lower", () => {
+      const previousScore = 78;
+      const currentScore = 73;
+      const delta = previousScore - currentScore;
+      const shouldAlert = previousScore !== null && delta > 5;
+      expect(shouldAlert).toBe(false);
+    });
+
+    it("should not alert when score is unchanged", () => {
+      const previousScore = 78;
+      const currentScore = 78;
+      const delta = previousScore - currentScore;
+      const shouldAlert = previousScore !== null && delta > 5;
+      expect(shouldAlert).toBe(false);
+    });
+
+    it("should not alert on first run (no previous score)", () => {
+      const previousScore = null;
+      const currentScore = 72;
+      const shouldAlert = previousScore !== null && previousScore - currentScore > 5;
+      expect(shouldAlert).toBe(false);
+    });
+  });
+
+  // AC-4: audit_system flag disabled → no audit
+  describe("AC-4: Feature flag gate", () => {
+    it("should have audit_system flag defaulting to false", () => {
+      const features = require("../../config/features.json");
+      expect(features.audit_system).toBe(false);
+    });
+
+    it("should skip audit when feature flag is disabled", () => {
+      // Simulates the guard in pulse()
+      const flagEnabled = false; // audit_system is off
+      const lastAuditAt = null; // never ran
+      const dayAgo = Date.now() - 24 * 60 * 60 * 1000;
+      const shouldRun = flagEnabled && (!lastAuditAt || new Date(lastAuditAt).getTime() < dayAgo);
+      expect(shouldRun).toBe(false);
+    });
+
+    it("should run audit when feature flag is enabled and time has elapsed", () => {
+      const flagEnabled = true; // audit_system is on
+      const lastAuditAt = null; // never ran
+      const dayAgo = Date.now() - 24 * 60 * 60 * 1000;
+      const shouldRun = flagEnabled && (!lastAuditAt || new Date(lastAuditAt).getTime() < dayAgo);
+      expect(shouldRun).toBe(true);
+    });
+  });
+});
+
+describe("HeartbeatState audit fields", () => {
+  it("should include lastAuditAt in default state", () => {
+    const state = createDefaultState();
+    expect(state.lastAuditAt).toBeNull();
+  });
+
+  it("should include lastAuditScore in default state", () => {
+    const state = createDefaultState();
+    expect(state.lastAuditScore).toBeNull();
+  });
+
+  it("should allow setting audit fields", () => {
+    const state = createDefaultState();
+    state.lastAuditAt = "2026-03-20T12:00:00.000Z";
+    state.lastAuditScore = 85;
+    expect(state.lastAuditAt).toBe("2026-03-20T12:00:00.000Z");
+    expect(state.lastAuditScore).toBe(85);
+  });
+});
+
 describe("Heartbeat Git Delta", () => {
   it("should detect no changes when SHA matches", () => {
     // getGitDelta calls spawnSync which will work in test env


### PR DESCRIPTION
Tache automatisee via /exec

ID: 159a5ff1
Priorite: P3

Ajouter un declenchement d'audit leger quotidien axes structure + tests uniquement dans le heartbeat. Si le score regresse de plus de 5 points par rapport au dernier audit, emettre une alerte via notification-queue. Tracker lastAuditAt dans heartbeat-state.