### PR TITLE
feat: adopt HTML formatting for bot-side Telegram responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `commands/utilities.ts` | Composer: /speak, /export, /feature, /rollback + callbacks |
 | `commands/zz-messages.ts` | Composer: message handlers (text, voice, photo, document) with intent routing and SDD pipeline context injection |
 | `agent.ts` | Sub-agent execution: centralized spawnClaude() with branch-PR workflow |
+| `html-utils.ts` | HTML escaping for Telegram HTML parse_mode: escapeHtml() — extracted to avoid circular imports with memory sub-modules |
 | `result.ts` | Custom Result<T, E> discriminant type with ok/err constructors and isOk/isErr type guards (vague 3) |
 | `tasks.ts` | Task CRUD: backlog → in_progress → review → done lifecycle |
 | `memory.ts` | Barrel re-export for memory sub-modules (see `src/memory/`) |
@@ -172,7 +173,7 @@ Details : voir [docs/WORKFLOW-PIPELINE.md](docs/WORKFLOW-PIPELINE.md) et [docs/W
 - Git workflow: feature branch → PR → CI (must pass) → merge to master
 - CI verification: after creating a PR, always run `./scripts/wait-ci.sh` to verify CI passes before announcing completion. Never declare a PR ready without confirmed green CI.
 - Error handling: always destructure `{ error }` from Supabase operations and log with `log.error` (via `createLogger` from `src/logger.ts`)
-- Telegram responses: plain text only, no markdown formatting
+- Telegram responses: LLM responses (callClaude) use plain text via sendResponse. Bot-side formatting functions (formatBacklog, formatMetrics, etc.) use HTML via sendResponseHtml — escapeHtml() mandatory for all dynamic content interpolated in HTML strings.
 - Voice messages: always respond with voice + text (dual format)
 - Language: French for user-facing, English for code/comments
 - Barrel convention: any module refactored into a sub-directory MUST keep a barrel file at the original path (re-exports only, no logic) so existing imports remain unchanged

--- a/docs/reviews/implement-modes-de-mise-en-page-telegram-html-markdown.md
+++ b/docs/reviews/implement-modes-de-mise-en-page-telegram-html-markdown.md
@@ -1,0 +1,61 @@
+# Implement Report — SPEC-modes-de-mise-en-page-telegram-html-markdown
+
+## Statut : DONE
+
+Tests : 2062 pass, 1 skip, 0 fail (avant : 2029 tests, +33 nouveaux tests)
+
+## Résumé
+
+Migration complète des fonctions de formatage bot-side de plain text vers HTML parse_mode Telegram. Invariant R2 maintenu : les réponses LLM (callClaude → sendResponse) restent en plain text.
+
+## Fichiers modifiés
+
+### Nouveau module
+- `src/html-utils.ts` — fonction `escapeHtml()` extraite pour éviter le cycle d'import circulaire `bot-context → memory → ideas → bot-context`. Couvre `&`, `<`, `>`, `"`, `'` (fix F-DA-1).
+
+### Modules source
+- `src/bot-context.ts` — re-export `escapeHtml` depuis html-utils ; `sendVoiceResponse` strip HTML avant Markdown (fix F-EC-2/R5)
+- `src/tasks.ts` — `formatBacklog` : sections `<b>`, titres `<b>`, IDs `<code>` ; `formatSprintSummary` : titre `<b>`
+- `src/pipeline-tracker.ts` — `formatStatusBar` : nom pipeline `<b>`, artifact `<code>`, summary `escapeHtml`
+- `src/memory/ideas.ts` — `formatIdeasList` : header `<b>`, IDs `<code>`, content `escapeHtml` (import direct html-utils pour éviter circulaire)
+- `src/memory/graph.ts` — `formatMemoryHealth` : header `<b>`, topAccessed `escapeHtml` (import direct html-utils)
+- `src/commands/quality.ts` — `formatMetrics` : titre `<b>` ; `formatMetricsComparison` : header `<b>`, IDs `<code>` ; 4 `sendResponse` → `sendResponseHtml`
+- `src/alerts.ts` — `formatMonitoringStats` : sections `<b>`, roles/mods `<code>` ; `formatAlerts` : header `<b>`, messages `escapeHtml`
+- `src/llm-ops.ts` — `formatLlmOpsSnapshot` : header `<b>`, rôles/raisons `escapeHtml` (fix F-DA-2/F-EC-1)
+- `src/commands/tasks.ts` — 4 `sendResponse` → `sendResponseHtml` ; `currentProject.name` `escapeHtml` (fix F-EC-3)
+- `src/commands/memory-cmds.ts` — `sendResponse` → `sendResponseHtml` pour formatMemoryHealth et formatIdeasList
+- `src/commands/sdd-flow.ts` — `parse_mode: "HTML"` pour job launch reply
+- `src/commands/utilities.ts` — `parse_mode: "HTML"` pour notif_sprint editMessageText (fix R6)
+- `src/commands/help.ts` — `/monitor` reply avec `parse_mode: "HTML"`
+- `CLAUDE.md` — règle R8 mise à jour : distinction LLM responses (plain text) vs bot-side formatting (HTML) ; entrée html-utils.ts ajoutée au tableau des modules
+
+### Tests ajoutés/modifiés
+- `tests/unit/tasks.test.ts` — V1 (sections `<b>`), V2 (`<code>` IDs), V3 (XSS escaping), V4 ([SDD] préservé), V5 (sprint `<b>`)
+- `tests/unit/pipeline-tracker.test.ts` — V6 (pipeline `<b>`), V7 (artifact `<code>`)
+- `tests/unit/memory.test.ts` — V8 (ideas header `<b>`), V9 (ideas IDs `<code>`)
+- `tests/unit/memory-evolution.test.ts` — V10 (memoryHealth `<b>`)
+- `tests/unit/bot-context.test.ts` — escapeHtml describe block (`&`, `<`, `>`, `"`, `'`) ; V14/V15 ordre strip HTML avant Markdown dans sendVoiceResponse
+- `tests/unit/alerts.test.ts` — V13 (XSS escaping dans messages), V13-spec (header `<b>`)
+- `tests/unit/monitoring.test.ts` — V12 (monitoring `<b>`)
+- `tests/unit/memory-cmds.test.ts` — regex mis à jour pour `sendResponseHtml`
+- `tests/unit/coding-standards.test.ts` — `html-utils.ts` ajouté à TYPES_ONLY_ALLOWLIST S6 (pure function, no side-effects)
+- `tests/integration/ideas-lifecycle.test.ts` — assertions mises à jour pour format HTML
+- `tests/generated/modes-de-mise-en-page-telegram-html-markdown.test.ts` — V10-V11 (quality.ts source checks), V16 (invariant R2 formatRetro), V18 (CLAUDE.md), V1/V5 (tasks.ts), V6/V7 (pipeline-tracker), escapeHtml unit tests
+
+## Défauts adversariaux résolus
+
+| Réf | Défaut | Résolution |
+|-----|--------|-----------|
+| F-DA-1 | escapeHtml manque `"` et `'` | Ajout `&quot;` et `&#39;` dans html-utils.ts |
+| F-DA-2/F-EC-1 | formatLlmOpsSnapshot non échappé | Migration llm-ops.ts avec escapeHtml |
+| F-EC-2 | sendVoiceResponse affiche HTML brut | Strip HTML avant Markdown dans sendVoiceResponse |
+| F-EC-3 | currentProject.name non échappé | escapeHtml dans tasks.ts command header |
+| F-DA-3 | Header concat dans tasks.ts | escapeHtml appliqué |
+| S7 | Import circulaire potentiel | html-utils.ts module indépendant |
+
+## Invariants respectés
+
+- R2 : callClaude → sendResponse (plain text) — zéro violation (V16 vérifie formatRetro)
+- R4 : HTML niveau 1 uniquement (`<b>`, `<code>`, `<a href>`) — pas de `<i>`, `<u>`, etc.
+- R5 : TTS strip HTML avant Markdown
+- S7 : Pas de cycle d'import (html-utils.ts racine indépendante)

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -11,6 +11,7 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { escapeHtml } from "./bot-context.ts";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -502,15 +503,15 @@ export function checkModuleErrors(): Alert[] {
 }
 
 /**
- * Format monitoring stats for /monitor command (plain text).
+ * Format monitoring stats for /monitor command (HTML formatting for sendResponseHtml).
  * S35: Includes trust scores section.
  */
 export function formatMonitoringStats(): string {
-  const lines: string[] = ["Monitoring Production", ""];
+  const lines: string[] = ["<b>Monitoring Production</b>", ""];
 
   // Response time
   const rtStats = getResponseTimeStats();
-  lines.push("Temps de reponse:");
+  lines.push("<b>Temps de reponse:</b>");
   if (rtStats.count === 0) {
     lines.push("  Pas de mesures");
   } else {
@@ -523,20 +524,22 @@ export function formatMonitoringStats(): string {
   // Spawn stats
   const spawnStats = getSpawnStats();
   lines.push("");
-  lines.push("Spawn Claude par role:");
+  lines.push("<b>Spawn Claude par role:</b>");
   if (Object.keys(spawnStats).length === 0) {
     lines.push("  Aucune execution");
   } else {
     for (const [role, data] of Object.entries(spawnStats)) {
       const total = data.success + data.failure;
-      lines.push(`  ${role}: ${data.success}/${total} OK (${data.failureRate}% echec)`);
+      lines.push(
+        `  <code>${escapeHtml(role)}</code>: ${data.success}/${total} OK (${data.failureRate}% echec)`,
+      );
     }
   }
 
   // Module errors
   const modErrors = getModuleErrorCounts();
   lines.push("");
-  lines.push("Erreurs modules (derniere heure):");
+  lines.push("<b>Erreurs modules (derniere heure):</b>");
   const sorted = Object.entries(modErrors)
     .sort(([, a], [, b]) => b - a)
     .slice(0, 5);
@@ -544,7 +547,7 @@ export function formatMonitoringStats(): string {
     lines.push("  Aucune erreur");
   } else {
     for (const [mod, count] of sorted) {
-      lines.push(`  ${mod}: ${count}`);
+      lines.push(`  <code>${escapeHtml(mod)}</code>: ${count}`);
     }
   }
 
@@ -557,13 +560,13 @@ export function formatAlerts(alerts: Alert[]): string {
   if (alerts.length === 0) return "Aucune alerte active. Tout est nominal.";
 
   const lines = [
-    `${alerts.length} alerte${alerts.length > 1 ? "s" : ""} detectee${alerts.length > 1 ? "s" : ""} :`,
+    `<b>${alerts.length} alerte${alerts.length > 1 ? "s" : ""} detectee${alerts.length > 1 ? "s" : ""}</b> :`,
     "",
   ];
 
   for (const alert of alerts) {
     const icon = alert.severity === "critical" ? "!!" : alert.severity === "warning" ? "!" : "~";
-    lines.push(`  ${icon} ${alert.message}`);
+    lines.push(`  ${icon} ${escapeHtml(alert.message)}`);
   }
 
   return lines.join("\n");

--- a/src/bot-context.ts
+++ b/src/bot-context.ts
@@ -625,15 +625,14 @@ function buildPrompt(
 // RESPONSE HELPERS
 // ============================================================
 
-export function escapeHtml(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+// Re-export escapeHtml for backward compatibility (importers of bot-context.ts)
+export { escapeHtml } from "./html-utils.ts";
 
 function sendResponse(ctx: Context, response: string): Promise<void> {
   const MAX_LENGTH = 4000;
   const opts = threadOpts(ctx);
 
-  if (!response || !response.trim()) return Promise.resolve();
+  if (!response?.trim()) return Promise.resolve();
 
   if (response.length <= MAX_LENGTH) {
     return ctx.reply(response, opts).then(() => {});
@@ -666,7 +665,7 @@ function sendResponseHtml(ctx: Context, response: string): Promise<void> {
   const MAX_LENGTH = 4000;
   const opts = { ...threadOpts(ctx), parse_mode: "HTML" as const };
 
-  if (!response || !response.trim()) return Promise.resolve();
+  if (!response?.trim()) return Promise.resolve();
 
   if (response.length <= MAX_LENGTH) {
     return ctx.reply(response, opts).then(() => {});
@@ -697,6 +696,12 @@ function sendResponseHtml(ctx: Context, response: string): Promise<void> {
 
 async function sendVoiceResponse(ctx: Context, response: string): Promise<void> {
   const clean = response
+    .replace(/<[^>]+>/g, "") // Strip HTML tags (R5 — must precede Markdown strip)
+    .replace(/&amp;/g, "&") // Decode HTML entities
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
     .replace(/```[\s\S]*?```/g, "")
     .replace(/`([^`]+)`/g, "$1")
     .replace(/\*\*([^*]+)\*\*/g, "$1")

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -223,7 +223,7 @@ export default function helpCommands(bctx: BotContext): Composer<Context> {
       }
     }
 
-    await ctx.reply(parts.join("\n"), threadOpts(ctx));
+    await ctx.reply(parts.join("\n"), { ...threadOpts(ctx), parse_mode: "HTML" as const });
   });
 
   return composer;

--- a/src/commands/memory-cmds.ts
+++ b/src/commands/memory-cmds.ts
@@ -48,7 +48,7 @@ export default function memoryCmds(bctx: BotContext): Composer<Context> {
       await ctx.replyWithChatAction("typing");
       try {
         const stats = await memoryHealthStats(bctx.supabase);
-        await bctx.sendResponse(ctx, formatMemoryHealth(stats));
+        await bctx.sendResponseHtml(ctx, formatMemoryHealth(stats));
       } catch (error) {
         log.error("Brain health error", { error: String(error) });
         await ctx.reply("Erreur lors du calcul des metriques memoire.", bctx.threadOpts(ctx));
@@ -225,14 +225,14 @@ Reponds en texte brut, sans markdown.`;
     // /ideas or /ideas list — show new + reviewed ideas
     if (subcommand === "list" || (!input && subcommand === "list")) {
       const ideas = await listIdeas(bctx.supabase);
-      await bctx.sendResponse(ctx, formatIdeasList(ideas));
+      await bctx.sendResponseHtml(ctx, formatIdeasList(ideas));
       return;
     }
 
     // /ideas all — show all ideas including archived
     if (subcommand === "all") {
       const ideas = await listIdeas(bctx.supabase, ["new", "reviewed", "promoted", "archived"]);
-      await bctx.sendResponse(ctx, formatIdeasList(ideas));
+      await bctx.sendResponseHtml(ctx, formatIdeasList(ideas));
       return;
     }
 

--- a/src/commands/quality.ts
+++ b/src/commands/quality.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { Composer, type Context, InlineKeyboard } from "grammy";
 import { formatAlerts, runAllChecks } from "../alerts.ts";
 import type { BotContext } from "../bot-context.ts";
+import { escapeHtml } from "../bot-context.ts";
 import { buildQualityNavKeyboard } from "../inline-menus.ts";
 import { formatCostSummary, getSprintCostSummary, getTotalCost } from "../llm-ops.ts";
 import { createLogger } from "../logger.ts";
@@ -152,7 +153,7 @@ async function getAllSprintMetrics(supabase: SupabaseClient): Promise<SprintMetr
 function formatMetrics(metrics: SprintMetrics): string {
   if (!metrics) return "Pas de metriques disponibles pour ce sprint.";
   const lines = [
-    `Metriques Sprint ${metrics.sprint_id}`,
+    `<b>Metriques Sprint ${escapeHtml(metrics.sprint_id)}</b>`,
     "",
     `Taches: ${metrics.tasks_completed}/${metrics.tasks_planned} (${metrics.completion_rate ?? 0}%)`,
   ];
@@ -175,11 +176,13 @@ function formatMetrics(metrics: SprintMetrics): string {
 
 function formatMetricsComparison(metricsList: SprintMetrics[]): string {
   if (metricsList.length === 0) return "Pas de metriques disponibles.";
-  const lines = ["Evolution des sprints", ""];
+  const lines = ["<b>Evolution des sprints</b>", ""];
   for (const m of metricsList) {
     const rate = m.completion_rate ?? 0;
     const bar = "=".repeat(Math.round(rate / 5)) + " " + rate + "%";
-    lines.push(`${m.sprint_id}: ${bar} (${m.tasks_completed}/${m.tasks_planned})`);
+    lines.push(
+      `<code>${escapeHtml(m.sprint_id)}</code>: ${bar} (${m.tasks_completed}/${m.tasks_planned})`,
+    );
   }
   return lines.join("\n");
 }
@@ -335,7 +338,7 @@ export default function qualityComposer(bctx: BotContext): Composer<Context> {
 
     if (arg === "all" || arg === "compare") {
       const all = await getAllSprintMetrics(bctx.supabase);
-      await bctx.sendResponse(ctx, formatMetricsComparison(all));
+      await bctx.sendResponseHtml(ctx, formatMetricsComparison(all));
       return;
     }
 
@@ -354,7 +357,7 @@ export default function qualityComposer(bctx: BotContext): Composer<Context> {
       await ctx.reply("Aucune metrique disponible pour ce sprint.", bctx.threadOpts(ctx));
       return;
     }
-    await bctx.sendResponse(ctx, formatMetrics(metrics));
+    await bctx.sendResponseHtml(ctx, formatMetrics(metrics));
     // Navigation keyboard to other quality commands
     const navKb = buildQualityNavKeyboard();
     await ctx.reply("Voir aussi :", { ...bctx.threadOpts(ctx), reply_markup: navKb });
@@ -372,7 +375,7 @@ export default function qualityComposer(bctx: BotContext): Composer<Context> {
       return;
     }
     const all = await getAllSprintMetrics(bctx.supabase);
-    await bctx.sendResponse(ctx, formatMetricsComparison(all));
+    await bctx.sendResponseHtml(ctx, formatMetricsComparison(all));
     const navKb = buildQualityNavKeyboard();
     await ctx.reply("Voir aussi :", { ...bctx.threadOpts(ctx), reply_markup: navKb });
   });
@@ -479,7 +482,7 @@ export default function qualityComposer(bctx: BotContext): Composer<Context> {
 
     await ctx.replyWithChatAction("typing");
     const alerts = await runAllChecks(bctx.supabase, sprintId);
-    await bctx.sendResponse(ctx, formatAlerts(alerts));
+    await bctx.sendResponseHtml(ctx, formatAlerts(alerts));
   });
 
   // /cost

--- a/src/commands/sdd-flow.ts
+++ b/src/commands/sdd-flow.ts
@@ -10,6 +10,7 @@
 import { spawnSync } from "bun";
 import { Composer, type Context, InlineKeyboard } from "grammy";
 import type { BotContext } from "../bot-context.ts";
+import { escapeHtml } from "../bot-context.ts";
 import { getConfig } from "../config.ts";
 import { assembleHandoffContext } from "../conversation-handoff.ts";
 import { isJobManagerEnabled, launch } from "../job-manager.ts";
@@ -287,8 +288,8 @@ export default function sddFlowComposer(bctx: BotContext): Composer<Context> {
           const updatedTracker = await getTracker(chatId, threadId);
           const statusBar = updatedTracker ? formatStatusBar(updatedTracker) : "";
           await ctx.reply(
-            `Job lance ${jobType} (id: ${jobId})\n${statusBar || `Pipeline: ${name}`}`,
-            bctx.threadOpts(ctx),
+            `Job lance ${escapeHtml(jobType)} (id: <code>${escapeHtml(String(jobId))}</code>)\n${statusBar || `Pipeline: ${escapeHtml(name)}`}`,
+            { ...bctx.threadOpts(ctx), parse_mode: "HTML" as const },
           );
         } catch (error) {
           log.error("SDD job launch error", { error: String(error), action, name });

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -8,6 +8,7 @@
 import { Composer, type Context } from "grammy";
 import { z } from "zod";
 import type { BotContext } from "../bot-context.ts";
+import { escapeHtml } from "../bot-context.ts";
 import { getConfig } from "../config.ts";
 import { buildOnboardingKeyboard } from "../inline-menus.ts";
 import { enqueue } from "../notification-queue.ts";
@@ -136,7 +137,7 @@ export default function tasksCommands(bctx: BotContext): Composer<Context> {
     if (filter) {
       // Explicit project filter
       const tasks = await getBacklog(bctx.supabase, { project: filter });
-      await bctx.sendResponse(ctx, formatBacklog(tasks));
+      await bctx.sendResponseHtml(ctx, formatBacklog(tasks));
     } else {
       // Auto-scope to current project
       const currentProject = await resolveProjectContext(
@@ -147,8 +148,8 @@ export default function tasksCommands(bctx: BotContext): Composer<Context> {
         bctx.supabase,
         currentProject ? { project_id: currentProject.id } : undefined,
       );
-      const header = currentProject ? `Backlog — ${currentProject.name}\n\n` : "";
-      await bctx.sendResponse(ctx, header + formatBacklog(tasks));
+      const header = currentProject ? `Backlog — ${escapeHtml(currentProject.name)}\n\n` : "";
+      await bctx.sendResponseHtml(ctx, header + formatBacklog(tasks));
     }
   });
 
@@ -184,23 +185,23 @@ export default function tasksCommands(bctx: BotContext): Composer<Context> {
       }
       const summary = await getSprintSummary(bctx.supabase, current);
       const tasks = await getBacklog(bctx.supabase, { sprint: current, ...projectFilter });
-      const header = currentProject ? `${currentProject.name} — ` : "";
+      const header = currentProject ? `${escapeHtml(currentProject.name)} — ` : "";
       const text =
         header +
         formatSprintSummary(current, summary) +
         "\n\n" +
         formatBacklog(tasks, `Taches ${current}`);
-      await bctx.sendResponse(ctx, text);
+      await bctx.sendResponseHtml(ctx, text);
       return;
     }
 
     // /sprint S01 — show that sprint
     const summary = await getSprintSummary(bctx.supabase, arg);
     const tasks = await getBacklog(bctx.supabase, { sprint: arg, ...projectFilter });
-    const header = currentProject ? `${currentProject.name} — ` : "";
+    const header = currentProject ? `${escapeHtml(currentProject.name)} — ` : "";
     const text =
       header + formatSprintSummary(arg, summary) + "\n\n" + formatBacklog(tasks, `Taches ${arg}`);
-    await bctx.sendResponse(ctx, text);
+    await bctx.sendResponseHtml(ctx, text);
   });
 
   // /done — mark a task as done by ID prefix

--- a/src/commands/utilities.ts
+++ b/src/commands/utilities.ts
@@ -322,6 +322,7 @@ export default function utilitiesComposer(bctx: BotContext): Composer<Context> {
             await ctx.answerCallbackQuery();
             await ctx.editMessageText(
               summary ? formatSprintSummary(sprintId, summary) : "Sprint non trouve.",
+              { parse_mode: "HTML" as const },
             );
           } else {
             await ctx.answerCallbackQuery({ text: "Pas de sprint actif." });

--- a/src/html-utils.ts
+++ b/src/html-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * @module html-utils
+ * @description HTML escaping utilities for Telegram HTML parse_mode.
+ * Extracted to avoid circular imports between bot-context and memory sub-modules.
+ */
+
+/**
+ * Escape special HTML characters for safe interpolation in Telegram HTML messages.
+ * Covers text content (&, <, >) and attribute values (", ').
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/llm-ops.ts
+++ b/src/llm-ops.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { escapeHtml } from "./bot-context.ts";
 import { createLogger } from "./logger.ts";
 
 const log = createLogger("llm-ops");
@@ -499,18 +500,18 @@ export function sha256(content: string): string {
 // ── Formatting ──────────────────────────────────────────────
 
 /**
- * Format LlmOpsSnapshot for /monitor display (plain text).
+ * Format LlmOpsSnapshot for /monitor display (HTML formatting for sendResponseHtml).
  */
 export function formatLlmOpsSnapshot(snapshot: LlmOpsSnapshot): string {
-  const parts: string[] = ["LLM-OPS MONITORING"];
+  const parts: string[] = ["<b>LLM-OPS MONITORING</b>"];
 
   // Circuit-breakers
   const openCBs = snapshot.circuitBreakers.filter((cb) => cb.open);
   if (openCBs.length > 0) {
     parts.push("");
-    parts.push("Circuit-breakers ouverts:");
+    parts.push("<b>Circuit-breakers ouverts:</b>");
     for (const cb of openCBs) {
-      parts.push(`  ${cb.role}: ${cb.reason}`);
+      parts.push(`  <code>${escapeHtml(cb.role)}</code>: ${escapeHtml(cb.reason)}`);
     }
   } else {
     parts.push("");
@@ -522,7 +523,7 @@ export function formatLlmOpsSnapshot(snapshot: LlmOpsSnapshot): string {
     parts.push("");
     parts.push(`Prompt versions: ${snapshot.promptVersions.length} enregistrees`);
     for (const pv of snapshot.promptVersions.slice(0, 5)) {
-      parts.push(`  ${pv.role}: ${pv.combinedHash.substring(0, 16)}...`);
+      parts.push(`  <code>${escapeHtml(pv.role)}</code>: ${pv.combinedHash.substring(0, 16)}...`);
     }
   }
 
@@ -532,7 +533,7 @@ export function formatLlmOpsSnapshot(snapshot: LlmOpsSnapshot): string {
     `Couts 7j: $${snapshot.costSummary.totalCostUsd.toFixed(4)} (${snapshot.costSummary.totalSpans} spans)`,
   );
   if (snapshot.costSummary.topRoleByCost) {
-    parts.push(`  Top role: ${snapshot.costSummary.topRoleByCost}`);
+    parts.push(`  Top role: <code>${escapeHtml(snapshot.costSummary.topRoleByCost)}</code>`);
   }
 
   return parts.join("\n");

--- a/src/memory/graph.ts
+++ b/src/memory/graph.ts
@@ -6,6 +6,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { isFeatureEnabled } from "../feature-flags.ts";
+import { escapeHtml } from "../html-utils.ts";
 import { createLogger } from "../logger.ts";
 import { getAgentMemories } from "./agent-memory.ts";
 import { classifyLinkContent } from "./classification.ts";
@@ -646,11 +647,11 @@ export async function memoryHealthStats(
 }
 
 /**
- * Format memory health stats as plain text for Telegram (no markdown).
+ * Format memory health stats for Telegram (HTML formatting via sendResponseHtml).
  */
 export function formatMemoryHealth(stats: MemoryHealthStats): string {
   const lines: string[] = [];
-  lines.push("SANTE MEMOIRE");
+  lines.push("<b>SANTE MEMOIRE</b>");
   lines.push(`Total: ${stats.total} memoires actives`);
 
   if (Object.keys(stats.byType).length > 0) {
@@ -673,7 +674,7 @@ export function formatMemoryHealth(stats: MemoryHealthStats): string {
     const top = stats.topAccessed
       .map(
         (t) =>
-          `"${t.content.slice(0, 40)}${t.content.length > 40 ? "..." : ""}" (${t.accessCount}x)`,
+          `"${escapeHtml(t.content.slice(0, 40))}${t.content.length > 40 ? "..." : ""}" (${t.accessCount}x)`,
       )
       .join(", ");
     lines.push(`Top acces: ${top}`);

--- a/src/memory/ideas.ts
+++ b/src/memory/ideas.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { escapeHtml } from "../html-utils.ts";
 import { createLogger } from "../logger.ts";
 
 const log = createLogger("memory.ideas");
@@ -156,19 +157,21 @@ export async function archiveIdea(supabase: SupabaseClient | null, id: string): 
 }
 
 /**
- * Format ideas list for Telegram (plain text, no markdown).
+ * Format ideas list for Telegram (HTML formatting via sendResponseHtml).
  */
 export function formatIdeasList(ideas: Idea[]): string {
   if (!ideas.length) return "Aucune idee trouvee.";
 
-  const lines: string[] = ["IDEES (" + ideas.length + ")"];
+  const lines: string[] = [`<b>IDEES (${ideas.length})</b>`];
   for (const idea of ideas) {
     const status = idea.idea_status.toUpperCase();
     const date = new Date(idea.created_at).toLocaleDateString("fr-FR");
     const topics = Array.isArray(idea.metadata?.topics)
-      ? " [" + (idea.metadata.topics as string[]).join(", ") + "]"
+      ? " [" + (idea.metadata.topics as string[]).map((t) => escapeHtml(t)).join(", ") + "]"
       : "";
-    lines.push(`${status} | ${idea.id.slice(0, 8)} | ${idea.content}${topics} (${date})`);
+    lines.push(
+      `${status} | <code>${idea.id.slice(0, 8)}</code> | ${escapeHtml(idea.content)}${topics} (${date})`,
+    );
   }
   return lines.join("\n");
 }

--- a/src/pipeline-tracker.ts
+++ b/src/pipeline-tracker.ts
@@ -10,6 +10,7 @@
 
 import { mkdir, readFile, rename, writeFile } from "fs/promises";
 import { join } from "path";
+import { escapeHtml } from "./bot-context.ts";
 import { createLogger } from "./logger.ts";
 
 const log = createLogger("pipeline-tracker");
@@ -248,10 +249,10 @@ export async function updateStep(
 
 /**
  * Format the status bar for a tracker (R6, V6, V7).
- * Plain-text only (Telegram convention).
+ * HTML formatting for Telegram (sendResponseHtml).
  */
 export function formatStatusBar(tracker: PipelineTracker): string {
-  const lines: string[] = [`Pipeline « ${tracker.name} »`];
+  const lines: string[] = [`<b>Pipeline « ${escapeHtml(tracker.name)} »</b>`];
 
   for (const phase of ALL_PHASES) {
     const step = tracker.steps[phase];
@@ -262,13 +263,13 @@ export function formatStatusBar(tracker: PipelineTracker): string {
 
     // Append summary if present
     if (step.summary) {
-      line += ` (${step.summary})`;
+      line += ` (${escapeHtml(step.summary)})`;
     }
 
     // Append artifact reference if present
     if (step.artifact) {
       const shortArtifact = step.artifact.split("/").pop() || step.artifact;
-      line += ` — ${shortArtifact}`;
+      line += ` — <code>${escapeHtml(shortArtifact)}</code>`;
     }
 
     // Append running indicator

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -11,6 +11,7 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { escapeHtml } from "./bot-context.ts";
 import { createLogger } from "./logger.ts";
 
 const log = createLogger("tasks");
@@ -220,7 +221,7 @@ export function formatTask(task: Task, index?: number): string {
 export function formatBacklog(tasks: Task[], title?: string): string {
   if (tasks.length === 0) return "Backlog vide. Utilise /task pour ajouter des taches.";
 
-  const header = title || "Backlog";
+  const header = title ? escapeHtml(title) : "Backlog";
   const grouped: Record<string, Task[]> = {};
 
   for (const t of tasks) {
@@ -242,13 +243,15 @@ export function formatBacklog(tasks: Task[], title?: string): string {
   for (const status of order) {
     const items = grouped[status];
     if (!items || items.length === 0) continue;
-    sections.push(`-- ${sectionNames[status]} --`);
+    sections.push(`<b>${sectionNames[status]}</b>`);
     for (const t of items) {
       const prio = PRIORITY_LABELS[t.priority] || "";
       const sprint = t.sprint ? ` (${t.sprint})` : "";
       const id = t.id.substring(0, 8);
       const sddTag = t.sdd_pipeline_name ? "[SDD] " : "";
-      sections.push(`  ${prio} ${sddTag}${t.title}${sprint}  [${id}]`);
+      sections.push(
+        `  ${prio} ${sddTag}<b>${escapeHtml(t.title)}</b>${sprint}  <code>${id}</code>`,
+      );
     }
     sections.push("");
   }
@@ -262,7 +265,7 @@ export function formatSprintSummary(
 ): string {
   const progress = summary.total > 0 ? Math.round((summary.done / summary.total) * 100) : 0;
   return [
-    `Sprint ${sprint}`,
+    `<b>Sprint ${escapeHtml(sprint)}</b>`,
     "",
     `Progression: ${summary.done}/${summary.total} (${progress}%)`,
     `A faire: ${summary.backlog}`,

--- a/tests/generated/modes-de-mise-en-page-telegram-html-markdown.test.ts
+++ b/tests/generated/modes-de-mise-en-page-telegram-html-markdown.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Generated tests — SPEC-modes-de-mise-en-page-telegram-html-markdown
+ *
+ * V10: formatMetrics returns <b>Metriques Sprint S23</b> as title
+ * V11: formatMetricsComparison returns <b>Evolution des sprints</b>
+ * V16: formatRetro is NOT sent via sendResponseHtml (invariant LLM)
+ * V18: CLAUDE.md rule distinguishes LLM responses and bot-side formatting
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+
+describe("HTML formatting migration — quality.ts", () => {
+  // V10: formatMetrics uses HTML bold for title
+  it("V10: formatMetrics source uses <b>Metriques Sprint ...<b> pattern", () => {
+    const source = readFileSync("src/commands/quality.ts", "utf-8");
+    expect(source).toContain("<b>Metriques Sprint");
+  });
+
+  // V11: formatMetricsComparison uses HTML bold for header
+  it("V11: formatMetricsComparison source uses <b>Evolution des sprints</b>", () => {
+    const source = readFileSync("src/commands/quality.ts", "utf-8");
+    expect(source).toContain("<b>Evolution des sprints</b>");
+  });
+
+  // V16: formatRetro is NOT sent via sendResponseHtml (invariant LLM — R2)
+  it("V16: formatRetro is never sent via sendResponseHtml", () => {
+    const source = readFileSync("src/commands/quality.ts", "utf-8");
+    // sendResponseHtml must not appear in proximity to formatRetro
+    const htmlCalls = [...source.matchAll(/sendResponseHtml\s*\([^)]+formatRetro/g)];
+    expect(htmlCalls).toHaveLength(0);
+  });
+});
+
+describe("HTML formatting migration — tasks.ts", () => {
+  // V1: formatBacklog uses <b> for section headers
+  it("V1: formatBacklog source uses <b> HTML tags for section headers", () => {
+    const source = readFileSync("src/tasks.ts", "utf-8");
+    // The source contains template literal with <b>${sectionNames[...]} pattern
+    expect(source).toContain("<b>${sectionNames[status]}</b>");
+  });
+
+  // V5: formatSprintSummary uses <b>Sprint ...
+  it("V5: formatSprintSummary source uses <b>Sprint HTML tag", () => {
+    const source = readFileSync("src/tasks.ts", "utf-8");
+    expect(source).toContain("<b>Sprint ");
+  });
+});
+
+describe("HTML formatting migration — pipeline-tracker.ts", () => {
+  // V6: formatStatusBar uses <b>Pipeline ...
+  it("V6: formatStatusBar source uses <b>Pipeline", () => {
+    const source = readFileSync("src/pipeline-tracker.ts", "utf-8");
+    expect(source).toContain("<b>Pipeline");
+  });
+
+  // V7: formatStatusBar uses <code> for artifact
+  it("V7: formatStatusBar source uses <code> for shortArtifact", () => {
+    const source = readFileSync("src/pipeline-tracker.ts", "utf-8");
+    expect(source).toContain("<code>");
+  });
+});
+
+describe("HTML formatting migration — CLAUDE.md R8", () => {
+  // V18: CLAUDE.md distinguishes LLM responses and bot-side formatting
+  it("V18: CLAUDE.md contains updated formatting rule with LLM vs bot-side distinction", () => {
+    const source = readFileSync("CLAUDE.md", "utf-8");
+    expect(source).toContain("LLM responses");
+    expect(source).toContain("sendResponseHtml");
+    expect(source).toContain("escapeHtml");
+  });
+});
+
+describe("escapeHtml — html-utils.ts", () => {
+  it("html-utils.ts exports escapeHtml function", () => {
+    const source = readFileSync("src/html-utils.ts", "utf-8");
+    expect(source).toContain("export function escapeHtml");
+  });
+
+  it("escapeHtml escapes & < > \" '", () => {
+    // Import via require to avoid TS issues in test
+    const mod = require("../../src/html-utils.ts");
+    expect(mod.escapeHtml("a & b")).toBe("a &amp; b");
+    expect(mod.escapeHtml("a < b")).toBe("a &lt; b");
+    expect(mod.escapeHtml("a > b")).toBe("a &gt; b");
+    expect(mod.escapeHtml('say "hi"')).toBe("say &quot;hi&quot;");
+    expect(mod.escapeHtml("it's")).toBe("it&#39;s");
+  });
+});

--- a/tests/integration/ideas-lifecycle.test.ts
+++ b/tests/integration/ideas-lifecycle.test.ts
@@ -137,7 +137,7 @@ describe("Ideas Multi-Source Creation", () => {
 
     expect(result).toBe("Voici mon idee:");
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
     expect(ideas.length).toBe(1);
     expect(ideas[0].content).toBe("Ajouter un cache Redis");
     expect(ideas[0].idea_status).toBe("new");
@@ -155,7 +155,7 @@ describe("Ideas Multi-Source Creation", () => {
     );
 
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
     expect(ideas.length).toBe(1);
     expect(ideas[0].metadata.source).toBe("auto-detect");
     expect(ideas[0].metadata.topics).toEqual(["architecture"]);
@@ -176,10 +176,10 @@ describe("Ideas Multi-Source Creation", () => {
     );
 
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
     expect(ideas.length).toBe(2);
 
-    const sources = ideas.map((i: any) => i.metadata.source).sort();
+    const sources = ideas.map((i: Record<string, unknown>) => i.metadata.source).sort();
     expect(sources).toEqual(["auto-detect", "intent-tag"]);
   });
 
@@ -246,7 +246,7 @@ describe("Ideas Deduplication Integration", () => {
     );
 
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
     expect(ideas.length).toBe(1);
   });
 
@@ -268,7 +268,7 @@ describe("Ideas Deduplication Integration", () => {
     await processMemoryIntents(supabase, "[IDEA: Mettre en place un cache]");
 
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
     expect(ideas.length).toBe(1);
   });
 
@@ -285,7 +285,7 @@ describe("Ideas Deduplication Integration", () => {
     );
 
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
     expect(ideas.length).toBe(1);
   });
 
@@ -373,7 +373,7 @@ describe("Ideas Status Filtering", () => {
   it("default listing shows new + reviewed only", async () => {
     const ideas = await listIdeas(supabase);
     expect(ideas.length).toBe(3);
-    const statuses = ideas.map((i: any) => i.idea_status);
+    const statuses = ideas.map((i: Record<string, unknown>) => i.idea_status);
     expect(statuses).not.toContain("promoted");
     expect(statuses).not.toContain("archived");
   });
@@ -384,7 +384,7 @@ describe("Ideas Status Filtering", () => {
     const after = await listIdeas(supabase);
     expect(after.length).toBe(3); // still 3: 1 new, 2 reviewed
 
-    const reviewed = after.filter((i: any) => i.idea_status === "reviewed");
+    const reviewed = after.filter((i: Record<string, unknown>) => i.idea_status === "reviewed");
     expect(reviewed.length).toBe(2);
   });
 
@@ -396,7 +396,7 @@ describe("Ideas Status Filtering", () => {
 
   it("archived ideas excluded from all active views", async () => {
     const active = await listIdeas(supabase, ["new", "reviewed", "promoted"]);
-    expect(active.every((i: any) => i.idea_status !== "archived")).toBe(true);
+    expect(active.every((i: Record<string, unknown>) => i.idea_status !== "archived")).toBe(true);
   });
 });
 
@@ -429,10 +429,10 @@ describe("Ideas Formatting Through Lifecycle", () => {
     ];
 
     const result = formatIdeasList(ideas);
-    expect(result).toContain("IDEES (3)");
-    expect(result).toContain("NEW | aaaa1111");
-    expect(result).toContain("REVIEWED | bbbb2222");
-    expect(result).toContain("PROMOTED | cccc3333");
+    expect(result).toContain("<b>IDEES (3)</b>");
+    expect(result).toContain("NEW | <code>aaaa1111</code>");
+    expect(result).toContain("REVIEWED | <code>bbbb2222</code>");
+    expect(result).toContain("PROMOTED | <code>cccc3333</code>");
     expect(result).toContain("[ui]");
     expect(result).toContain("[api, perf]");
   });
@@ -449,8 +449,8 @@ describe("Ideas Formatting Through Lifecycle", () => {
     ];
 
     const result = formatIdeasList(ideas);
-    expect(result).toContain("IDEES (1)");
-    expect(result).toContain("REVIEWED | dddd4444");
+    expect(result).toContain("<b>IDEES (1)</b>");
+    expect(result).toContain("REVIEWED | <code>dddd4444</code>");
   });
 });
 
@@ -471,8 +471,8 @@ describe("Ideas and Other Memory Types", () => {
     const memory = supabase._getTable("memory");
     expect(memory.length).toBe(2);
 
-    const fact = memory.find((m: any) => m.type === "fact");
-    const idea = memory.find((m: any) => m.type === "idea");
+    const fact = memory.find((m: Record<string, unknown>) => m.type === "fact");
+    const idea = memory.find((m: Record<string, unknown>) => m.type === "idea");
     expect(fact).toBeDefined();
     expect(idea).toBeDefined();
     expect(fact!.content).toBe("Le serveur tourne sur Bun");
@@ -491,8 +491,8 @@ describe("Ideas and Other Memory Types", () => {
     );
 
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
-    const goals = memory.filter((m: any) => m.type === "goal");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
+    const goals = memory.filter((m: Record<string, unknown>) => m.type === "goal");
     expect(ideas.length).toBe(1);
     expect(goals.length).toBe(2);
     expect(goals[0].metadata.source).toBe("action-item");
@@ -606,9 +606,12 @@ describe("Ideas Edge Cases", () => {
 
     expect(result).toBe("et aussi");
     const memory = supabase._getTable("memory");
-    const ideas = memory.filter((m: any) => m.type === "idea");
+    const ideas = memory.filter((m: Record<string, unknown>) => m.type === "idea");
     expect(ideas.length).toBe(2);
-    expect(ideas.map((i: any) => i.content).sort()).toEqual(["Idee deux", "Idee un"]);
+    expect(ideas.map((i: Record<string, unknown>) => i.content).sort()).toEqual([
+      "Idee deux",
+      "Idee un",
+    ]);
   });
 
   it("IDEA tag with empty content is still processed", async () => {

--- a/tests/unit/alerts.test.ts
+++ b/tests/unit/alerts.test.ts
@@ -208,4 +208,22 @@ describe("Alert Formatting", () => {
     const result = formatAlerts([]);
     expect(result).toContain("Aucune alerte");
   });
+
+  // V13: formatAlerts escapes dynamic message content
+  it("V13: formatAlerts escapes HTML special chars in alert messages", () => {
+    const result = formatAlerts([
+      { type: "stuck_task", severity: "critical", message: "a <b> c", data: {} },
+    ]);
+    expect(result).toContain("a &lt;b&gt; c");
+    expect(result).not.toContain("a <b> c");
+  });
+
+  // V13-spec: header uses <b> HTML tag
+  it("V13-spec: formatAlerts uses <b> for alert count header", () => {
+    const result = formatAlerts([
+      { type: "stuck_task", severity: "critical", message: "Test", data: {} },
+    ]);
+    expect(result).toContain("<b>");
+    expect(result).toContain("alerte");
+  });
 });

--- a/tests/unit/bot-context.test.ts
+++ b/tests/unit/bot-context.test.ts
@@ -24,28 +24,33 @@ import {
 
 // ── Mock Grammy Context ────────────────────────────────────
 
-function createMockCtx(overrides: Record<string, any> = {}) {
+function createMockCtx(overrides: Record<string, unknown> = {}): {
+  // biome-ignore lint/suspicious/noExplicitAny: mock Grammy context requires type coercion
+  ctx: any;
+  replies: string[];
+  voiceReplies: unknown[];
+} {
   const replies: string[] = [];
-  const voiceReplies: any[] = [];
+  const voiceReplies: unknown[] = [];
 
   return {
     ctx: {
-      chat: { id: overrides.chatId ?? 12345 },
+      chat: { id: (overrides.chatId as number) ?? 12345 },
       message: {
-        text: overrides.text || "test message",
+        text: (overrides.text as string) || "test message",
         message_thread_id: overrides.threadId,
-        message_id: overrides.messageId ?? 1,
+        message_id: (overrides.messageId as number) ?? 1,
         reply_to_message: overrides.replyToMessage,
       },
-      reply: async (text: string, _opts?: any) => {
+      reply: async (text: string, _opts?: Record<string, unknown>) => {
         replies.push(text);
         return { message_id: 99 };
       },
-      replyWithVoice: async (file: any, _opts?: any) => {
+      replyWithVoice: async (file: unknown, _opts?: Record<string, unknown>) => {
         voiceReplies.push(file);
         return { message_id: 100 };
       },
-    } as any,
+    },
     replies,
     voiceReplies,
   };
@@ -53,12 +58,13 @@ function createMockCtx(overrides: Record<string, any> = {}) {
 
 // ── Mock Bot ───────────────────────────────────────────────
 
-function createMockBot() {
+// biome-ignore lint/suspicious/noExplicitAny: mock Bot requires type coercion
+function createMockBot(): any {
   return {
     api: {
       sendMessage: async () => ({}),
     },
-  } as any;
+  };
 }
 
 // ── Tests ──────────────────────────────────────────────────
@@ -296,9 +302,10 @@ describe("bot-context", () => {
       const afterSdd = prompt.substring(sddStart);
       // The instruction ends before the next \n\n section header
       const nextSection = afterSdd.indexOf("\nVOICE CAPABILITIES");
-      const sddBlock = nextSection > 0
-        ? afterSdd.substring(0, nextSection)
-        : afterSdd.split("\n\n")[0] + "\n" + (afterSdd.split("\n\n")[1] || "");
+      const sddBlock =
+        nextSection > 0
+          ? afterSdd.substring(0, nextSection)
+          : afterSdd.split("\n\n")[0] + "\n" + (afterSdd.split("\n\n")[1] || "");
       const wordCount = sddBlock.split(/\s+/).filter(Boolean).length;
       expect(wordCount).toBeLessThan(100);
     });
@@ -322,6 +329,58 @@ describe("bot-context", () => {
     });
   });
 
+  // ── escapeHtml ─────────────────────────────────────────
+
+  describe("escapeHtml", () => {
+    // Import escapeHtml
+    it("escapes & < > characters", () => {
+      // test via the re-exported function
+      const { escapeHtml } = require("../../src/bot-context.ts");
+      expect(escapeHtml("a & b")).toBe("a &amp; b");
+      expect(escapeHtml("a < b")).toBe("a &lt; b");
+      expect(escapeHtml("a > b")).toBe("a &gt; b");
+    });
+
+    it("escapes \" and ' characters (F-DA-1 fix)", () => {
+      const { escapeHtml } = require("../../src/bot-context.ts");
+      expect(escapeHtml('say "hello"')).toBe("say &quot;hello&quot;");
+      expect(escapeHtml("it's fine")).toBe("it&#39;s fine");
+    });
+
+    it("returns empty string unchanged", () => {
+      const { escapeHtml } = require("../../src/bot-context.ts");
+      expect(escapeHtml("")).toBe("");
+    });
+
+    it("passes through safe text unchanged", () => {
+      const { escapeHtml } = require("../../src/bot-context.ts");
+      expect(escapeHtml("Hello world 123")).toBe("Hello world 123");
+    });
+  });
+
+  // ── sendVoiceResponse HTML strip (V14/V15) ─────────────
+
+  describe("sendVoiceResponse HTML strip", () => {
+    // V14/V15: source code check that HTML strip precedes Markdown strip
+    it("V14/V15: bot-context.ts strips HTML tags before Markdown in sendVoiceResponse", () => {
+      const fs = require("fs");
+      const source = fs.readFileSync("src/bot-context.ts", "utf-8");
+
+      // V14: HTML tag strip is present
+      expect(source).toContain("replace(/<[^>]+>/g");
+
+      // V15: HTML entities are decoded
+      expect(source).toContain('replace(/&amp;/g, "&")');
+      expect(source).toContain('replace(/&lt;/g, "<")');
+      expect(source).toContain('replace(/&gt;/g, ">")');
+
+      // V14: HTML strip comes before Markdown strip in the function
+      const htmlStripIdx = source.indexOf("replace(/<[^>]+>/g");
+      const markdownStripIdx = source.indexOf("replace(/```[\\s\\S]*?```/g");
+      expect(htmlStripIdx).toBeLessThan(markdownStripIdx);
+    });
+  });
+
   // ── sendResponse ───────────────────────────────────────
 
   describe("sendResponse", () => {
@@ -333,20 +392,20 @@ describe("bot-context", () => {
 
     it("sends a short response in a single message", async () => {
       const { ctx, replies } = createMockCtx();
-      await botCtx.sendResponse(ctx as any, "Hello there");
+      await botCtx.sendResponse(ctx, "Hello there");
       expect(replies).toHaveLength(1);
       expect(replies[0]).toBe("Hello there");
     });
 
     it("does nothing for empty response", async () => {
       const { ctx, replies } = createMockCtx();
-      await botCtx.sendResponse(ctx as any, "");
+      await botCtx.sendResponse(ctx, "");
       expect(replies).toHaveLength(0);
     });
 
     it("does nothing for whitespace-only response", async () => {
       const { ctx, replies } = createMockCtx();
-      await botCtx.sendResponse(ctx as any, "   \n  ");
+      await botCtx.sendResponse(ctx, "   \n  ");
       expect(replies).toHaveLength(0);
     });
 
@@ -354,7 +413,7 @@ describe("bot-context", () => {
       const { ctx, replies } = createMockCtx();
       // Build a string longer than 4000 characters
       const longText = "A".repeat(3000) + "\n\n" + "B".repeat(3000);
-      await botCtx.sendResponse(ctx as any, longText);
+      await botCtx.sendResponse(ctx, longText);
       expect(replies.length).toBeGreaterThan(1);
       // All chunks together should contain full content
       const joined = replies.join("");
@@ -363,15 +422,16 @@ describe("bot-context", () => {
     });
 
     it("includes message_thread_id in thread context", async () => {
-      const sentOpts: any[] = [];
-      const ctx = {
+      const sentOpts: Record<string, unknown>[] = [];
+      // biome-ignore lint/suspicious/noExplicitAny: mock Grammy context
+      const ctx: any = {
         chat: { id: 123 },
         message: { message_thread_id: 42 },
-        reply: async (_text: string, opts?: any) => {
-          sentOpts.push(opts);
+        reply: async (_text: string, opts?: Record<string, unknown>) => {
+          sentOpts.push(opts ?? {});
           return { message_id: 1 };
         },
-      } as any;
+      };
       await botCtx.sendResponse(ctx, "Threaded reply");
       expect(sentOpts.length).toBeGreaterThanOrEqual(1);
       expect(sentOpts[0]?.message_thread_id).toBe(42);
@@ -412,25 +472,25 @@ describe("bot-context", () => {
     describe("getThreadId", () => {
       it("returns threadId from context message", () => {
         const { ctx } = createMockCtx({ threadId: 42 });
-        expect(botCtx.getThreadId(ctx as any)).toBe(42);
+        expect(botCtx.getThreadId(ctx)).toBe(42);
       });
 
       it("returns undefined when no threadId", () => {
         const { ctx } = createMockCtx();
-        expect(botCtx.getThreadId(ctx as any)).toBeUndefined();
+        expect(botCtx.getThreadId(ctx)).toBeUndefined();
       });
     });
 
     describe("threadOpts", () => {
       it("returns message_thread_id when thread exists", () => {
         const { ctx } = createMockCtx({ threadId: 99 });
-        const opts = botCtx.threadOpts(ctx as any);
+        const opts = botCtx.threadOpts(ctx);
         expect(opts.message_thread_id).toBe(99);
       });
 
       it("returns empty object when no thread", () => {
         const { ctx } = createMockCtx();
-        const opts = botCtx.threadOpts(ctx as any);
+        const opts = botCtx.threadOpts(ctx);
         expect(opts.message_thread_id).toBeUndefined();
         expect(Object.keys(opts)).toHaveLength(0);
       });
@@ -439,14 +499,14 @@ describe("bot-context", () => {
     describe("heartbeatOpts", () => {
       it("returns chatId and threadId when in thread", () => {
         const { ctx } = createMockCtx({ chatId: 777, threadId: 55 });
-        const opts = botCtx.heartbeatOpts(ctx as any);
+        const opts = botCtx.heartbeatOpts(ctx);
         expect(opts.chatId).toBe(777);
         expect(opts.threadId).toBe(55);
       });
 
       it("returns chatId only when not in thread", () => {
         const { ctx } = createMockCtx({ chatId: 888 });
-        const opts = botCtx.heartbeatOpts(ctx as any);
+        const opts = botCtx.heartbeatOpts(ctx);
         expect(opts.chatId).toBe(888);
         expect(opts.threadId).toBeUndefined();
       });
@@ -460,13 +520,13 @@ describe("bot-context", () => {
             forum_topic_created: { name: "sprint" },
           },
         });
-        const name = botCtx.getTopicName(ctx as any);
+        const name = botCtx.getTopicName(ctx);
         expect(name).toBe("sprint");
       });
 
       it("returns undefined when no threadId", () => {
         const { ctx } = createMockCtx();
-        const name = botCtx.getTopicName(ctx as any);
+        const name = botCtx.getTopicName(ctx);
         expect(name).toBeUndefined();
       });
 
@@ -478,11 +538,11 @@ describe("bot-context", () => {
             forum_topic_created: { name: "idees" },
           },
         });
-        botCtx.getTopicName(ctx1 as any);
+        botCtx.getTopicName(ctx1);
 
         // Second call without forum_topic_created but same threadId
         const { ctx: ctx2 } = createMockCtx({ threadId: 300 });
-        const name = botCtx.getTopicName(ctx2 as any);
+        const name = botCtx.getTopicName(ctx2);
         expect(name).toBe("idees");
       });
     });
@@ -520,7 +580,7 @@ describe("bot-context", () => {
             forum_topic_created: { name: "claude-relay" },
           },
         });
-        const result = botCtx.commandGuard(ctx as any, "exec");
+        const result = botCtx.commandGuard(ctx, "exec");
         expect(result).toBeNull();
       });
 
@@ -532,7 +592,7 @@ describe("bot-context", () => {
           },
         });
         // "task" is not in serveur's allowedCommands
-        const result = botCtx.commandGuard(ctx as any, "task");
+        const result = botCtx.commandGuard(ctx, "task");
         expect(result).not.toBeNull();
         expect(result).toContain("n'est pas disponible");
         expect(result).toContain("serveur");
@@ -540,7 +600,7 @@ describe("bot-context", () => {
 
       it("returns null when no topic (DM context)", () => {
         const { ctx } = createMockCtx();
-        const result = botCtx.commandGuard(ctx as any, "exec");
+        const result = botCtx.commandGuard(ctx, "exec");
         expect(result).toBeNull();
       });
     });

--- a/tests/unit/coding-standards.test.ts
+++ b/tests/unit/coding-standards.test.ts
@@ -331,6 +331,8 @@ describe("Coding standards — S6: createLogger mandatory", () => {
       "Pure async functions returning Alert[] — no internal side-effects needing logging",
     // Utility with graceful degradation — no logging needed
     "feature-flags.ts": "Simple file-based toggle — no side-effects needing logging",
+    // Pure string escaping utility — no side-effects needing logging
+    "html-utils.ts": "Pure escapeHtml function — no runtime logic or side-effects",
     // Command composers: thin wrappers delegating to logged modules via bctx
     "commands/jobs.ts": "Thin Composer delegating to job-manager.ts — logging in dependency",
     "commands/profile.ts":
@@ -481,10 +483,10 @@ describe("Coding standards — S7: no circular imports", () => {
     const cycles = findCycles(graph);
 
     if (cycles.length > 0) {
-      const cycleDescriptions = cycles.map((cycle) => cycle.join(" -> ")).join("\n  ");
+      const _cycleDescriptions = cycles.map((cycle) => cycle.join(" -> ")).join("\n  ");
       expect(cycles.length).toBe(
         0,
-        // `Circular imports detected:\n  ${cycleDescriptions}`
+        // `Circular imports detected:\n  ${_cycleDescriptions}`
       );
     }
   });

--- a/tests/unit/memory-cmds.test.ts
+++ b/tests/unit/memory-cmds.test.ts
@@ -30,9 +30,9 @@ describe("/brain health dispatch", () => {
     );
     expect(healthBlock).not.toBeNull();
 
-    // V11: The formatted result is sent via sendResponse
+    // V11: The formatted result is sent via sendResponseHtml (HTML formatting)
     const sendMatch = source.match(
-      /memoryHealthStats\([\s\S]*?formatMemoryHealth\(\s*stats\s*\)[\s\S]*?sendResponse/,
+      /memoryHealthStats\([\s\S]*?formatMemoryHealth\(\s*stats\s*\)[\s\S]*?sendResponseHtml/,
     );
     expect(sendMatch).not.toBeNull();
   });

--- a/tests/unit/memory-evolution.test.ts
+++ b/tests/unit/memory-evolution.test.ts
@@ -814,8 +814,8 @@ describe("memoryHealthStats", () => {
 // ── formatMemoryHealth ──────────────────────────────────────────
 
 describe("formatMemoryHealth", () => {
-  // V10: Produces readable plain text (no markdown)
-  it("[V10] formats stats as plain text without markdown", () => {
+  // V10: Produces readable HTML (no markdown)
+  it("[V10] formats stats as HTML without markdown", () => {
     const stats: MemoryHealthStats = {
       total: 142,
       byType: { fact: 98, goal: 12, idea: 23, preference: 9 },
@@ -849,6 +849,8 @@ describe("formatMemoryHealth", () => {
     expect(text).not.toContain("**");
     expect(text).not.toContain("##");
     expect(text).not.toContain("```");
+    // HTML header
+    expect(text).toContain("<b>SANTE MEMOIRE</b>");
   });
 
   it("handles empty stats (total=0)", () => {

--- a/tests/unit/memory.test.ts
+++ b/tests/unit/memory.test.ts
@@ -94,8 +94,8 @@ describe("processMemoryIntents", () => {
     expect(result).toBe("Response text.");
     const memory = supabase._getTable("memory");
     expect(memory.length).toBe(2);
-    expect(memory.some((m: any) => m.type === "fact")).toBe(true);
-    expect(memory.some((m: any) => m.type === "goal")).toBe(true);
+    expect(memory.some((m: Record<string, unknown>) => m.type === "fact")).toBe(true);
+    expect(memory.some((m: Record<string, unknown>) => m.type === "goal")).toBe(true);
   });
 
   it("returns response unchanged when no tags", async () => {
@@ -445,7 +445,7 @@ describe("findDuplicateIdea", () => {
   });
 
   it("returns matching idea content when duplicate found", async () => {
-    supabase._registerFunction("search", (opts: any) => {
+    supabase._registerFunction("search", (opts: Record<string, unknown>) => {
       expect(opts.body.table).toBe("memory");
       expect(opts.body.match_threshold).toBe(0.85);
       return [{ content: "Ajouter un mode sombre", type: "idea", similarity: 0.92 }];
@@ -643,7 +643,9 @@ describe("listIdeas", () => {
   it("returns new and reviewed ideas by default", async () => {
     const ideas = await listIdeas(supabase);
     expect(ideas.length).toBe(2);
-    expect(ideas.every((i: any) => ["new", "reviewed"].includes(i.idea_status))).toBe(true);
+    expect(
+      ideas.every((i: Record<string, unknown>) => ["new", "reviewed"].includes(i.idea_status)),
+    ).toBe(true);
   });
 
   it("filters by custom status", async () => {
@@ -659,7 +661,9 @@ describe("listIdeas", () => {
 
   it("excludes non-idea types", async () => {
     const ideas = await listIdeas(supabase, ["new", "reviewed", "promoted", "archived"]);
-    expect(ideas.every((i: any) => i.type === undefined || i.id !== "f1")).toBe(true);
+    expect(ideas.every((i: Record<string, unknown>) => i.type === undefined || i.id !== "f1")).toBe(
+      true,
+    );
   });
 
   it("returns empty array for null supabase", async () => {
@@ -849,11 +853,11 @@ describe("formatIdeasList", () => {
     ];
 
     const result = formatIdeasList(ideas);
-    expect(result).toContain("IDEES (2)");
-    expect(result).toContain("NEW | abcd1234");
+    expect(result).toContain("<b>IDEES (2)</b>");
+    expect(result).toContain("NEW | <code>abcd1234</code>");
     expect(result).toContain("Mode sombre");
     expect(result).toContain("[ui, dashboard]");
-    expect(result).toContain("REVIEWED | efgh5678");
+    expect(result).toContain("REVIEWED | <code>efgh5678</code>");
     expect(result).toContain("Cache Redis");
   });
 
@@ -877,6 +881,37 @@ describe("formatIdeasList", () => {
     expect(result).toContain("Simple idea");
     expect(result).not.toContain("[");
   });
+
+  // V8: formatIdeasList header uses <b> HTML tag
+  it("V8: formatIdeasList returns <b>IDEES (n)</b> as header", () => {
+    const ideas = [
+      {
+        id: "abcd1234-5678-0000-0000-000000000000",
+        content: "Test idea",
+        idea_status: "new" as const,
+        metadata: {},
+        created_at: "2026-03-14T10:00:00Z",
+      },
+    ];
+    const result = formatIdeasList(ideas);
+    expect(result).toContain("<b>IDEES (1)</b>");
+  });
+
+  // V9: formatIdeasList IDs are in <code> tags
+  it("V9: formatIdeasList wraps IDs in <code> tags", () => {
+    const ideas = [
+      {
+        id: "abcd1234-5678-0000-0000-000000000000",
+        content: "Test idea",
+        idea_status: "new" as const,
+        metadata: {},
+        created_at: "2026-03-14T10:00:00Z",
+      },
+    ];
+    const result = formatIdeasList(ideas);
+    expect(result).toContain("<code>");
+    expect(result).toContain("abcd1234");
+  });
 });
 
 describe("archiveOldMemories", () => {
@@ -887,7 +922,7 @@ describe("archiveOldMemories", () => {
   });
 
   it("calls archive_old_memories RPC with default threshold", async () => {
-    supabase._registerRpc("archive_old_memories", (params: any) => {
+    supabase._registerRpc("archive_old_memories", (params: Record<string, unknown>) => {
       expect(params.days_threshold).toBe(90);
       return 5;
     });
@@ -897,7 +932,7 @@ describe("archiveOldMemories", () => {
   });
 
   it("calls archive_old_memories RPC with custom threshold", async () => {
-    supabase._registerRpc("archive_old_memories", (params: any) => {
+    supabase._registerRpc("archive_old_memories", (params: Record<string, unknown>) => {
       expect(params.days_threshold).toBe(30);
       return 2;
     });

--- a/tests/unit/monitoring.test.ts
+++ b/tests/unit/monitoring.test.ts
@@ -113,4 +113,12 @@ describe("formatMonitoringStats", () => {
     expect(output).toContain("Spawn Claude par role");
     expect(output).toContain("Erreurs modules");
   });
+
+  // V12: section headers use <b> HTML tags
+  it("V12: formatMonitoringStats uses <b> for section headers", () => {
+    const output = formatMonitoringStats();
+    expect(output).toContain("<b>");
+    expect(output).toContain("<b>Monitoring Production</b>");
+    expect(output).toContain("<b>Temps de reponse:</b>");
+  });
 });

--- a/tests/unit/pipeline-tracker.test.ts
+++ b/tests/unit/pipeline-tracker.test.ts
@@ -337,10 +337,10 @@ describe("pipeline-tracker", () => {
       };
 
       const bar = formatStatusBar(tracker);
-      expect(bar).toStartWith("Pipeline « refactoring-memoire »");
+      expect(bar).toStartWith("<b>Pipeline « refactoring-memoire »</b>");
     });
 
-    it("is plain text only (no markdown)", () => {
+    it("uses HTML bold for pipeline name header (no markdown)", () => {
       const tracker: PipelineTracker = {
         chatId: 12345,
         name: "test",
@@ -358,9 +358,61 @@ describe("pipeline-tracker", () => {
       };
 
       const bar = formatStatusBar(tracker);
-      expect(bar).not.toContain("*");
+      // HTML format, not Markdown
+      expect(bar).not.toContain("**");
       expect(bar).not.toContain("_");
-      expect(bar).not.toContain("`");
+      // HTML <b> tags are used instead
+      expect(bar).toContain("<b>Pipeline");
+    });
+
+    // V6-spec: pipeline name wrapped in <b> tags
+    it("V6-spec: formatStatusBar wraps pipeline name in <b> HTML tags", () => {
+      const tracker: PipelineTracker = {
+        chatId: 12345,
+        name: "mon-feature",
+        steps: {
+          explore: { phase: "explore", status: "pending" },
+          discuss: { phase: "discuss", status: "pending" },
+          spec: { phase: "spec", status: "pending" },
+          challenge: { phase: "challenge", status: "pending" },
+          implement: { phase: "implement", status: "pending" },
+          review: { phase: "review", status: "pending" },
+          doc: { phase: "doc", status: "pending" },
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      const bar = formatStatusBar(tracker);
+      const lines = bar.split("\n");
+      expect(lines[0]).toContain("<b>Pipeline");
+      expect(lines[0]).toContain("</b>");
+    });
+
+    // V7-spec: artifact shortname in <code> tags
+    it("V7-spec: formatStatusBar wraps artifact shortname in <code> tags", () => {
+      const tracker: PipelineTracker = {
+        chatId: 12345,
+        name: "test",
+        steps: {
+          explore: {
+            phase: "explore",
+            status: "ok",
+            artifact: "docs/explorations/EXPLORE-mon-feature.md",
+          },
+          discuss: { phase: "discuss", status: "pending" },
+          spec: { phase: "spec", status: "pending" },
+          challenge: { phase: "challenge", status: "pending" },
+          implement: { phase: "implement", status: "pending" },
+          review: { phase: "review", status: "pending" },
+          doc: { phase: "doc", status: "pending" },
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      const bar = formatStatusBar(tracker);
+      expect(bar).toContain("<code>EXPLORE-mon-feature.md</code>");
     });
 
     it("adds ... indicator for running status", () => {

--- a/tests/unit/tasks.test.ts
+++ b/tests/unit/tasks.test.ts
@@ -241,6 +241,81 @@ describe("Task Formatting", () => {
     expect(formatBacklog([])).toContain("Backlog vide");
   });
 
+  // V1: formatBacklog returns <b>En cours</b> for in-progress tasks
+  it("V1: formatBacklog returns <b>En cours</b> section header", () => {
+    const tasks: Task[] = [
+      {
+        id: "aabbccdd-0000-0000-0000-000000000001",
+        title: "Task A",
+        status: "in_progress",
+        priority: 2,
+        sprint: "S12",
+      } as Task,
+    ];
+    const result = formatBacklog(tasks);
+    expect(result).toContain("<b>En cours</b>");
+  });
+
+  // V2: formatBacklog returns <code>${id}</code> for task IDs
+  it("V2: formatBacklog returns <code> for task IDs", () => {
+    const tasks: Task[] = [
+      {
+        id: "aabbccdd-eeff-0011-2233-445566778899",
+        title: "Task A",
+        status: "backlog",
+        priority: 2,
+        sprint: null,
+      } as Task,
+    ];
+    const result = formatBacklog(tasks);
+    expect(result).toContain("<code>");
+    expect(result).toContain("aabbccdd");
+  });
+
+  // V3: formatBacklog escapes special chars in task titles
+  it("V3: formatBacklog escapes XSS in task titles", () => {
+    const tasks: Task[] = [
+      {
+        id: "aabbccdd-0000-0000-0000-000000000001",
+        title: "<XSS>",
+        status: "backlog",
+        priority: 2,
+        sprint: null,
+      } as Task,
+    ];
+    const result = formatBacklog(tasks);
+    expect(result).toContain("&lt;XSS&gt;");
+    expect(result).not.toContain("<XSS>");
+  });
+
+  // V4: formatBacklog preserves [SDD] indicator
+  it("V4: formatBacklog preserves [SDD] for SDD tasks", () => {
+    const tasks: Task[] = [
+      {
+        id: "aabbccdd-0000-0000-0000-000000000001",
+        title: "Pipeline task",
+        status: "in_progress",
+        priority: 2,
+        sprint: "S12",
+        sdd_pipeline_name: "my-pipeline",
+      } as Task,
+    ];
+    const result = formatBacklog(tasks);
+    expect(result).toContain("[SDD]");
+  });
+
+  // V5: formatSprintSummary returns <b>Sprint S12</b>
+  it("V5: formatSprintSummary returns bold sprint title", () => {
+    const result = formatSprintSummary("S12", {
+      total: 16,
+      backlog: 3,
+      in_progress: 2,
+      review: 1,
+      done: 10,
+    });
+    expect(result).toContain("<b>Sprint S12</b>");
+  });
+
   it("formatSprintSummary produces correct output", () => {
     const result = formatSprintSummary("S12", {
       total: 16,


### PR DESCRIPTION
## Summary

- Migration des fonctions de formatage bot-side (formatBacklog, formatMetrics, formatStatusBar, formatIdeasList, formatMemoryHealth, formatAlerts, formatLlmOpsSnapshot, formatMonitoringStats) du plain text vers le HTML parse_mode de Telegram
- Ajout du module `src/html-utils.ts` avec `escapeHtml()` pour prevenir les injections XSS et eviter les imports circulaires
- Mise a jour de `sendVoiceResponse` pour stripper le HTML avant le TTS (invariant R5)
- Invariant R2 maintenu : les reponses LLM via `callClaude` restent en plain text
- Mise a jour de la regle CLAUDE.md pour distinguer LLM responses (plain text) et bot-side formatting (HTML)
- 33 nouveaux tests couvrant le formatage HTML, l'echappement XSS et les invariants architecturaux

Spec : `docs/specs/SPEC-modes-de-mise-en-page-telegram-html-markdown.md`
Rapport d'implementation : `docs/reviews/implement-modes-de-mise-en-page-telegram-html-markdown.md`

## Test plan

- [x] 2062 tests pass, 0 fail (pre-push hook valide)
- [x] Biome lint + typecheck passent (pre-commit hook valide)
- [x] Tests V1-V18 couvrent chaque regle de la spec
- [x] Tests XSS verifient l'echappement de `& < > " '`
- [x] Test V16 verifie que formatRetro n'utilise pas sendResponseHtml (invariant R2)
- [ ] Verification manuelle sur Telegram : backlog, sprint, metrics, ideas, alerts, pipeline status

🤖 Generated with [Claude Code](https://claude.com/claude-code)