### PR TITLE
feat: agent context enrichi (S40) + orphan recovery watchdog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `commands/utilities.ts` | Composer: /speak, /export, /feature, /rollback + callbacks |
 | `commands/zz-messages.ts` | Composer: message handlers (text, voice, photo, document) with intent routing and SDD pipeline context injection |
 | `agent.ts` | Sub-agent execution: centralized spawnClaude() with branch-PR workflow |
+| `agent-context.ts` | Enriched Supabase context builder for SDD agents: buildAgentContext(supabase, role, phase) with parallel fetch, timeout, size cap |
 | `html-format-helpers.ts` | Shared HTML formatting helpers for Telegram: sectionTitle, separator, progressBar, kvLine, statusIcon, bulletList, collapsibleSection |
 | `html-utils.ts` | HTML escaping for Telegram HTML parse_mode: escapeHtml() — extracted to avoid circular imports with memory sub-modules |
 | `result.ts` | Custom Result<T, E> discriminant type with ok/err constructors and isOk/isErr type guards (vague 3) |
@@ -68,7 +69,9 @@ Modular TypeScript monolith: Telegram bot orchestrating BMad AI agents via Supab
 | `inline-menus.ts` | Progressive inline menu system: category grouping, dynamic keyboards, onboarding, quality/notify navigation |
 | `intent-detection.ts` | Two-tier intent detection: regex fast-path + LLM fallback, feature_request intent for SDD pipeline trigger |
 | `heartbeat.ts` | Autonomous heartbeat: periodic pulse, alert checks, memory archival |
+| `heartbeat-sdd-watchdog.ts` | SDD pipeline watchdog: detects orphaned/stuck pipeline phases (cross-process read) |
 | `heartbeat-prompt.ts` | Heartbeat prompt builder: system prompt, delta formatting, decision schema |
+| `heartbeat-sdd-watchdog.ts` | SDD pipeline watchdog for heartbeat: detects orphaned/stuck pipeline phases |
 
 ### Telegram Commands
 

--- a/config/features.json
+++ b/config/features.json
@@ -10,5 +10,7 @@
   "sdd_auto_deploy": true,
   "nlu_feature_request": true,
   "prompt_feedback_loop": true,
-  "sdd_feedback_llm_overlay": false
+  "sdd_feedback_llm_overlay": false,
+  "sdd_pipeline_watchdog": true,
+  "agent_context_injection": false
 }

--- a/docs/explorations/EXPLORE-contexte-agent-enrichi-s40.md
+++ b/docs/explorations/EXPLORE-contexte-agent-enrichi-s40.md
@@ -1,0 +1,145 @@
+---
+phase: 0-explore
+generated_at: "2026-03-26T14:00:00Z"
+subject: "Contexte agent enrichi : injection de donnees Supabase dans les agents SDD"
+verdict: GO
+next_step: "dev-spec"
+---
+
+# Exploration : Contexte agent enrichi pour les agents SDD
+
+## Section 1 -- Probleme
+
+Les agents SDD (definis dans `.claude/agents/` et orchestres par `src/sdd-agents.ts`) sont executes via `spawnClaude()` avec un prompt textuel statique. Ils ne recoivent aucune donnee dynamique provenant de Supabase : ni les taches en cours du sprint, ni les metriques de velocite/rework, ni l'historique memoire (faits, objectifs, decisions), ni les evenements recents des agents precedents.
+
+Ce manque de contexte a des consequences concretes :
+- L'agent **spec-architect** genere des specs qui ne tiennent pas compte des taches existantes (risque de doublons ou d'incompatibilites)
+- L'agent **explorer** ne sait pas quels patterns ont deja ete explores recemment
+- Les agents **challenge** (devils-advocate, edge-case-hunter, simplicity-skeptic) ne peuvent pas evaluer l'impact sur les taches en cours ou la dette technique connue
+- L'agent **implementer** ne connait pas la velocite du sprint ni les contraintes budgetaires
+- L'agent **reviewer** ne peut pas verifier la coherence avec les decisions architecturales passees
+
+Le MCP memory server (`mcp/memory-server.ts`) expose deja un outil `get_project_context` qui agrege faits, objectifs, sprint summary et taches recentes. Mais ce contexte n'est jamais injecte dans les prompts des agents SDD.
+
+## Section 2 -- Etat de l'art
+
+| # | Source | Type | Date | Resume | Pertinence |
+|---|--------|------|------|--------|:----------:|
+| 1 | [Anthropic — Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) | Article technique officiel | 2026-03-26 | Hierarchie a 3 couches (persistent / time-sensitive / transient), just-in-time retrieval, compaction, notes structurees, sous-agents specialises retournant des resumes condenses | Forte |
+| 2 | [Claude Code Docs — Create custom subagents](https://code.claude.com/docs/en/sub-agents) | Documentation officielle | 2026-03-26 | Les subagents recoivent uniquement le system prompt + env basique. Champ `skills` pour injecter du contenu, champ `mcpServers` pour brancher des serveurs MCP, `--append-system-prompt` pour enrichir le prompt CLI | Forte |
+| 3 | [Context Engineering: A Complete Guide](https://codeconductor.ai/blog/context-engineering) | Blog technique | 2026-03-26 | Multi-layer context (identity/policy, time-sensitive data, transient state), external memory retrieval, hierarchique (summary first, context second, task last) | Moyenne |
+
+### Synthese des enseignements cles
+
+**Architecture a couches** : Anthropic recommande 3 couches de contexte — persistante (identite, politique), sensible au temps (donnees fraiches), et transitoire (etat conversationnel). Notre cas d'usage mappe directement : le profil agent (.md) est la couche persistante, les donnees Supabase (taches, metriques, memoire) sont la couche time-sensitive, et le handoff conversationnel est la couche transitoire.
+
+**Just-in-time vs pre-loading** : La documentation Anthropic recommande un hybride — pre-charger les donnees critiques pour la vitesse, tout en permettant la decouverte autonome pour le reste. Pour nos agents SDD, le pre-loading est plus adapte car les agents sont spawnes en one-shot (pas de dialogue interactif avec Supabase).
+
+**Budget de contexte** : Les donnees injectees doivent etre compactes. Anthropic insiste sur "the smallest set of high-signal tokens". Un bloc de contexte Supabase ne devrait pas depasser 1000-1500 tokens pour laisser de la place au prompt metier de l'agent.
+
+**MCP vs injection directe** : La documentation Claude Code montre que les subagents supportent `mcpServers` pour brancher des serveurs MCP directement. Cependant, nos agents sont spawnes via `spawnClaude()` (CLI), pas comme des subagents natifs Claude Code. L'injection dans le prompt via `--append-system-prompt` est la voie la plus directe et testable.
+
+**Skills injection** : Le champ `skills` des subagents injecte du contenu statique. Pour du contenu dynamique (donnees Supabase), l'injection dans le prompt reste la solution la plus flexible.
+
+## Section 3 -- Archeologie codebase
+
+| # | Fichier/Module | Observation | Impact potentiel |
+|---|---------------|-------------|:----------------:|
+| 1 | `src/sdd-agents.ts` (580 LOC) | 6 fonctions `runSdd*` construisent chacune un prompt statique. Seul `runSddSpec` recoit un `HandoffSummary`. Toutes recoivent `bctx: BotContext` (sauf explore) qui donne acces a `bctx.supabase` | Modification directe — point d'injection principal |
+| 2 | `src/agent.ts` — `spawnClaude()` | Flag `--append-system-prompt` pour injecter du contexte systeme. Le prompt est passe via `-p`. Les deux sont des vecteurs d'injection | Aucune modification necessaire — API deja suffisante |
+| 3 | `src/bot-context.ts` — `BotContext` | Interface partagee contenant `supabase: SupabaseClient \| null`. Deja passe a la plupart des `runSdd*` | Reutilisable tel quel |
+| 4 | `src/conversation-handoff.ts` | Pattern existant : `assembleHandoffContext()` + `formatHandoffForAgent()` transforment des messages en bloc texte injectable. Seul utilise pour la phase spec | Pattern a generaliser |
+| 5 | `mcp/memory-server.ts` — `get_project_context` | Outil MCP qui agrege facts, goals, sprint_summary, recent_tasks via Supabase REST. Code d'assemblage deja ecrit (lignes 189-241) | Logique a extraire/dupliquer cote relay |
+| 6 | `src/memory/core.ts` — `getMemoryContext()` | Fonction existante qui recupere faits + objectifs depuis Supabase et les formate en texte. Utilisee dans `zz-messages.ts` pour le prompt conversationnel | Directement reutilisable |
+| 7 | `src/tasks.ts` — `getBacklog()`, `getSprintSummary()`, `getCurrentSprint()` | Fonctions CRUD existantes pour les taches et sprint. Deja utilisees par le MCP server | Directement reutilisables |
+| 8 | `src/llm-ops.ts` — `getSprintCostSummary()` | Cout et budget du sprint courant. Pertinent pour l'agent implementer (budget awareness) | Optionnel, valeur ajoutee |
+| 9 | `src/memory/agent-memory.ts` — `getAgentMemories()` | Memoire specifique par role d'agent. Pourrait injecter les apprentissages passes du meme role | Valeur ajoutee forte |
+| 10 | `src/prompt-overlay.ts` — `buildEnrichedPrompt()` | Mecanisme existant d'enrichissement de prompt par role. Pattern a suivre pour l'injection de contexte | Pattern de reference |
+| 11 | `src/commands/sdd-flow.ts` (L260-272) | Point d'appel des `runSdd*`. La phase spec appelle deja `getRecentMessages()` pour le handoff. Les autres phases n'appellent rien de Supabase | Point d'integration secondaire |
+| 12 | `src/pipeline-tracker.ts` | Tracker de l'etat du pipeline SDD. Pourrait fournir le contexte "ou en est-on dans le pipeline" a chaque agent | Optionnel, valeur ajoutee |
+
+### Points de friction
+
+1. **Performance** : Chaque appel Supabase ajoute de la latence avant le spawn de l'agent. Il faut paralliser les requetes (`Promise.all`) et imposer un timeout court (3-5s) avec fallback gracieux.
+2. **Taille du contexte** : Le system prompt des agents est deja consequent (~2000-4000 tokens). Il faut limiter le bloc de contexte injecte a ~1000-1500 tokens maximum.
+3. **runSddExplore n'a pas bctx** : La fonction `runSddExplore` ne recoit pas de `BotContext`, donc pas d'acces direct a Supabase. Il faudra soit lui passer `bctx`, soit passer le contexte deja assemble.
+4. **Tests** : Le module `sdd-agents.ts` utilise des hooks injectables (`_writeFileHook`, `_spawnSyncHook`, etc.) pour le testing. Le nouveau code de recuperation Supabase devra suivre le meme pattern.
+
+### Actifs reutilisables
+
+- `getMemoryContext(supabase)` : retourne deja un bloc texte "Faits connus" + "Objectifs actifs"
+- `getSprintSummary(supabase, sprintId)` : retourne `{total, backlog, in_progress, review, done}`
+- `getCurrentSprint(supabase)` : retourne le sprint actif
+- `getBacklog(supabase)` : retourne les taches actives
+- `getAgentMemories(supabase, role)` : retourne les memoires specifiques a un role d'agent
+- `assembleHandoffContext()` / `formatHandoffForAgent()` : pattern de formatage texte pour injection prompt
+- `buildEnrichedPrompt()` : pattern d'enrichissement de system prompt
+- Les test hooks de `sdd-agents.ts` : pattern a reproduire pour le nouveau code
+
+## Section 4 -- Matrice d'alternatives
+
+| Critere | A: Status quo | B: Injection prompt (pre-fetch + formatage) | C: MCP Server aux agents | D: Fichier contexte pre-genere |
+|---------|:------------:|:-------------------------------------------:|:------------------------:|:-----------------------------:|
+| **Complexite** (obligatoire) | S | M | L | M |
+| **Valeur ajoutee** (obligatoire) | Low | High | High | Med |
+| **Risque technique** (obligatoire) | Low | Low | High | Med |
+| *Impact maintenance* | Aucun | Faible — module isole | Fort — config MCP + sync | Moyen — lifecycle fichier |
+| *Reversibilite* | N/A | Haute — supprimer le bloc suffit | Faible — infrastructure MCP | Haute — supprimer le fichier |
+
+### Discussion des options
+
+**A: Status quo** — Les agents continuent de travailler sans contexte Supabase. Pas de risque, pas de cout, mais la qualite des outputs reste limitee par le manque de contexte projet. Les agents ne peuvent pas prendre de decisions informees par l'etat reel du projet.
+
+**B: Injection prompt (pre-fetch + formatage)** — Creer un module `src/agent-context.ts` qui expose une fonction `buildAgentContext(supabase, role, phase)`. Cette fonction recupere en parallele (Promise.all avec timeout) : memoire contextuelle, sprint summary, taches en cours, et agent memories. Elle formate le tout en un bloc texte compact (<1500 tokens) injecte dans le prompt via `--append-system-prompt`. Chaque `runSdd*` appelle cette fonction avant `spawnClaude()`. Avantages : reutilise les fonctions Supabase existantes, testable via hooks, reversible, pas de changement d'infrastructure. Inconvenient mineur : ajout de latence (attenuee par parallelisation + timeout).
+
+**C: MCP Server aux agents** — Brancher le MCP memory server sur chaque agent spawn via le flag CLI ou la config subagent `mcpServers`. Les agents pourraient alors utiliser les outils MCP (`get_tasks`, `get_project_context`, etc.) pour decouvrir le contexte eux-memes. Avantages : contexte a la demande, pas de pre-fetch. Inconvenients : les agents SDD sont spawnes en one-shot via `spawnClaude()` CLI, pas comme des subagents natifs — brancher un MCP server stdio dans ce contexte est complexe et fragile. Necessite de modifier l'interface `spawnClaude()` pour supporter les MCP servers. Risque de surconsommation de tokens si l'agent fait trop de requetes MCP.
+
+**D: Fichier contexte pre-genere** — Avant chaque spawn, generer un fichier temporaire `context-{name}.json` contenant les donnees Supabase, et dire a l'agent de le lire. Avantages : separation claire. Inconvenients : gestion du lifecycle du fichier (creation, nettoyage), l'agent doit savoir le lire (instruction supplementaire), moins direct que l'injection prompt, risque de fichiers orphelins.
+
+## Section 5 -- Verdict et justification
+
+**Verdict : GO** — avec l'option B (injection prompt pre-fetch + formatage).
+
+Justification :
+1. **Alignement avec les best practices** (Axe 1) : L'approche par injection directe suit la recommandation Anthropic de "pre-load critical data for speed" dans un contexte d'agents one-shot. La structure a couches (system prompt agent = persistent, contexte Supabase = time-sensitive, handoff = transient) est exactement le pattern recommande.
+
+2. **Reutilisation massive du code existant** (Axe 2) : Les fonctions `getMemoryContext()`, `getSprintSummary()`, `getCurrentSprint()`, `getBacklog()`, `getAgentMemories()` sont deja implementees et testees. Le pattern `formatHandoffForAgent()` montre exactement comment formater du contexte pour injection. Le pattern `buildEnrichedPrompt()` montre comment enrichir un prompt sans modifier les fichiers agents. Le cout d'implementation est donc faible.
+
+3. **Meilleur rapport complexite/valeur** (Axe 3) : L'option B est la seule a combiner complexite M, valeur High, risque Low, et haute reversibilite. L'option C (MCP) serait plus elegante conceptuellement mais implique un risque technique nettement plus eleve pour un gain marginal. L'option D n'offre pas d'avantage clair sur B.
+
+4. **Compatibilite avec l'existant** : Le module `sdd-agents.ts` utilise deja des patterns d'injection (hooks de test, `enrichPrompt()`). Ajouter un appel `buildAgentContext()` avant chaque `spawnClaude()` est une extension naturelle du code existant.
+
+## Section 6 -- Input pour etape suivante
+
+### Option recommandee : B — Module `agent-context.ts`
+
+**Fichiers concernes :**
+- `src/agent-context.ts` — **nouveau** — module de construction de contexte agent
+- `src/sdd-agents.ts` — **modifier** — appeler `buildAgentContext()` dans chaque `runSdd*`
+- `tests/unit/agent-context.test.ts` — **nouveau** — tests unitaires
+
+**Contraintes identifiees :**
+- Budget de tokens : le bloc de contexte injecte ne doit pas depasser ~1500 tokens (~6000 caracteres)
+- Latence : timeout de 3-5 secondes sur les requetes Supabase, fallback gracieux (contexte vide)
+- `runSddExplore` : necessite de recevoir `supabase` en parametre (ou le contexte pre-assemble)
+- Pattern de test : utiliser des hooks injectables comme le reste de `sdd-agents.ts`
+- Coding standard S6 : le nouveau module doit utiliser `createLogger`
+- Coding standard S2 : pas de `process.env` direct
+
+**Questions ouvertes a resoudre pendant la spec :**
+1. Quelles donnees exactes par phase ? (ex: l'explorer n'a pas besoin des metriques de cout, mais le reviewer a besoin des decisions architecturales)
+2. Faut-il un feature flag `agent_context_injection` pour pouvoir desactiver si probleme de performance ?
+3. Le contexte doit-il etre injecte dans le `systemPrompt` (via `--append-system-prompt`) ou dans le `prompt` (via `-p`) ? Le system prompt est plus semantiquement correct mais le prompt est plus visible pour le debug.
+4. Faut-il aussi injecter l'etat du pipeline SDD (via `pipeline-tracker.ts`) pour que chaque agent sache ou en est le pipeline ?
+
+**Input pour spec :**
+```
+Module: src/agent-context.ts
+Fonction principale: buildAgentContext(supabase, role, phase, options?)
+Retour: string (bloc texte formate, <1500 tokens)
+Donnees sources: getMemoryContext, getSprintSummary, getCurrentSprint, getBacklog, getAgentMemories
+Pattern: parallelisation Promise.all + timeout 3-5s + fallback ""
+Integration: appel dans chaque runSdd* de sdd-agents.ts, injection via systemPrompt
+Tests: hooks injectables, mock Supabase
+Exploration: docs/explorations/EXPLORE-contexte-agent-enrichi-s40.md
+```

--- a/docs/explorations/EXPLORE-orphan-recovery-pont-heartbeat-sdd.md
+++ b/docs/explorations/EXPLORE-orphan-recovery-pont-heartbeat-sdd.md
@@ -1,0 +1,130 @@
+---
+phase: 0-explore
+generated_at: "2026-03-26T10:00:00Z"
+subject: "Orphan recovery — pont heartbeat-SDD pour detection et remediation des pipelines bloques"
+verdict: GO
+next_step: "dev-spec"
+---
+
+# Orphan recovery — pont heartbeat-SDD pour detection et remediation des pipelines bloques
+
+## Section 1 — Probleme
+
+Le heartbeat (`src/heartbeat.ts`) tourne en PM2 cron toutes les 10 minutes. Il surveille git, CI, sprint, taches stales, PRs ouvertes, et peut notifier ou creer des taches. Cependant, il n'a **aucune connaissance de l'etat des pipelines SDD**.
+
+Le pipeline SDD (`src/pipeline-tracker.ts`) persiste son etat dans `~/.claude-relay/pipelines.json` avec 7 phases (explore -> discuss -> spec -> challenge -> implement -> review -> doc). Chaque phase peut etre en status `pending`, `running`, `ok`, ou `failed`. Les jobs SDD tournent en arriere-plan via le job-manager (`src/job-manager.ts`) avec un timeout de 2 heures.
+
+Le probleme : quand un pipeline SDD est bloque — agent crash sans timeout, phase `running` depuis >30 min sans progres, job-manager qui a perdu le contexte apres un restart PM2 — **personne ne le detecte**. L'utilisateur peut ne pas remarquer qu'un pipeline attend indefiniment. Les scenarios concrets :
+
+1. **Agent crash silencieux** : `spawnClaude()` echoue mais le step reste en `running` dans pipelines.json (race condition entre job-manager et pipeline-tracker).
+2. **Timeout non-detecte** : le job-manager a un timeout de 2h, mais si PM2 restart le relay avant, les jobs `running` sont marques `failed` dans jobs.json mais pipelines.json n'est pas mis a jour (processus differents).
+3. **Phase stuck** : la phase `discuss` (conversationnelle) peut rester en `running` indefiniment si l'utilisateur oublie la conversation.
+4. **Orphelin post-restart** : apres un restart du heartbeat ou du relay, les pipelines en cours ne sont pas re-evalues.
+
+L'auto-avancement event-driven (`src/sdd-auto-advance.ts`) gere deja le **happy path** : quand un job termine avec succes, il tente d'avancer automatiquement. Cette exploration concerne uniquement le **watchdog pour les cas d'echec** — la detection et la remediation des pipelines orphelins ou bloques.
+
+## Section 2 — Etat de l'art
+
+| # | Source | Type | Date | Resume | Pertinence |
+|---|--------|------|------|--------|:----------:|
+| 1 | [HeartBeat Pattern — Martin Fowler](https://martinfowler.com/articles/patterns-of-distributed-systems/heartbeat.html) | Pattern catalogue | 2023 | Pattern heartbeat pour detection de pannes dans les systemes distribues. Timeout = multiple de l'intervalle de heartbeat. Eviter les faux positifs via buffering temporel. Remediation : reassignment des donnees du noeud defaillant | High |
+| 2 | [Design a Distributed Job Scheduler — AlgoMaster](https://blog.algomaster.io/p/design-a-distributed-job-scheduler) | Article technique | 2025 | Patterns pour detection de jobs orphelins : query `status=running AND last_heartbeat < threshold`. Retry avec backoff exponentiel. Escalation : apres `max_retries`, dead-letter. Checkpointing pour jobs longs. Recommande de traquer chaque tentative d'execution separement | High |
+
+**Synthese des enseignements cles :**
+
+Le pattern heartbeat classique (Martin Fowler) s'applique directement a notre cas : le heartbeat PM2 (10 min) joue le role du moniteur, et les pipelines SDD jouent le role des noeuds surveilles. Le timeout de detection doit etre un multiple de l'intervalle : avec un heartbeat a 10 min, detecter un pipeline bloque apres 30 min (3x) est un seuil raisonnable qui evite les faux positifs.
+
+L'article AlgoMaster apporte le pattern concret de detection d'orphelins : scanner la table (ou le fichier) des jobs pour ceux en `running` dont le `startedAt` depasse un seuil. C'est exactement ce que pipelines.json permet deja — chaque step a un champ `startedAt` optionnel. L'escalation recommandee (retry -> notification -> dead-letter/backlog) correspond bien aux actions que le heartbeat sait deja executer (`notify`, `task_create`).
+
+Point cle des deux sources : la detection doit etre **idempotente**. Le heartbeat tourne toutes les 10 min — il ne doit pas re-notifier a chaque pulse pour le meme pipeline bloque. Le systeme de cooldowns existant dans `heartbeat-prompt.ts` repond deja a ce besoin.
+
+## Section 3 — Archeologie codebase
+
+| # | Fichier/Module | Observation | Impact potentiel |
+|---|---------------|-------------|:----------------:|
+| 1 | `src/heartbeat.ts` (747 LOC) | Service PM2 cron 10 min. Importe deja `readFile`, `join`, le pattern de collecte de delta. N'importe aucun module SDD. Actions : notify, task_create, none. Section "Periodic tasks" gated par timestamps dans HeartbeatState | High — point d'integration principal |
+| 2 | `src/heartbeat-prompt.ts` (235 LOC) | Types HeartbeatState, HeartbeatDelta, HeartbeatAction. Pas de champ pour pipeline SDD. HeartbeatState a deja des champs `last*At` pour gater les taches periodiques (hourly, daily). Extensible | High — extension du state necessaire |
+| 3 | `src/pipeline-tracker.ts` (365 LOC) | Source de verite pour l'etat SDD. Persistence dans `pipelines.json`. Chaque PipelineStep a : `phase`, `status`, `startedAt?`, `completedAt?`, `jobId?`. Le `startedAt` est set quand status passe a `running`. TTL 7 jours. Export `loadPipelines()` est private mais `getTracker()` et la Map interne sont accessibles | High — source de donnees a lire |
+| 4 | `src/job-manager.ts` (782 LOC) | Jobs persistent dans `jobs.json`. Au chargement, les jobs `running`/`pending` sont marques `failed` avec error `"restart"`. Timeout job = 2h. Mais : la notification de completion (qui met a jour pipeline-tracker) ne se declenche pas pour les jobs marques `failed` au restart — c'est le trou dans la maille | Critical — source du probleme d'orphelins |
+| 5 | `src/sdd-auto-advance.ts` (282 LOC) | Gere le happy-path : apres completion OK, tente d'avancer. Circuit breaker a 3 auto-avances max. Feature flag `sdd_auto_advance`. Ne gere PAS les cas d'echec ou de stuck | Medium — complementaire, pas de conflit |
+| 6 | `src/notification-queue.ts` | Fonction `enqueue()` pour notifications via bot ou MCP bridge. Deja utilisee par heartbeat pour les alertes | Low — reutilisable tel quel |
+| 7 | `src/sdd-task-sync.ts` (111 LOC) | Sync phase -> statut tache. Pas de logique de detection de stuck. Utile si remediation implique de mettre a jour le statut de la tache liee | Low — reutilisable |
+| 8 | `src/alerts.ts` (570 LOC) | `checkStuckTasks()` detecte deja les taches Supabase en `in_progress` depuis >24h. Pattern directement transposable aux pipelines SDD | Medium — pattern a reproduire |
+| 9 | `config/heartbeat-state.json` | State persiste du heartbeat. Extensible avec de nouveaux champs `last*At` | Low — modification triviale |
+
+**Points de friction identifies :**
+
+1. **Couplage heartbeat <-> pipeline-tracker** : le heartbeat est un processus PM2 isole. Il doit lire `pipelines.json` mais ne peut pas utiliser la Map in-memory de pipeline-tracker (processus different). Solution : lire directement le fichier JSON, comme le fait deja `loadPipelines()`.
+
+2. **Desynchronisation jobs.json / pipelines.json** : quand PM2 restart le relay, job-manager marque les jobs comme `failed` dans jobs.json, mais ne met pas a jour pipelines.json (l'update se fait dans `sendJobCompletionNotification` qui n'est pas appelee pour les jobs marques failed au restart). C'est la source principale d'orphelins.
+
+3. **Phase conversationnelle "discuss"** : cette phase est `running` tant que l'utilisateur n'a pas fini de discuter. Un timeout de 30 min serait un faux positif. Il faut un seuil different (24h ?) ou exclure cette phase du watchdog.
+
+**Actifs reutilisables :**
+
+- `HeartbeatState.cooldowns` : evite les notifications repetees
+- `HeartbeatState.last*At` pattern : gate temporelle pour les taches periodiques
+- `enqueue()` : notification immediate via bot
+- `addTask()` : creation de taches backlog
+- `checkStuckTasks()` pattern : query + seuil + alerte
+- `readFile(pipelines.json)` : lecture directe sans import du module
+
+## Section 4 — Matrice d'alternatives
+
+| Critere | A: Status quo | B: Watchdog heartbeat (lecture pipelines.json) | C: Watchdog dans le relay (in-process timer) | D: Recovery au restart uniquement |
+|---------|:------------:|:-----------:|:-----------:|:-----------:|
+| **Complexite** (obligatoire) | S | M | M | S |
+| **Valeur ajoutee** (obligatoire) | Low | High | High | Med |
+| **Risque technique** (obligatoire) | Low (dette) | Low | Med | Low |
+| *Impact maintenance* | Negatif (dette invisible) | Faible (50-80 LOC) | Moyen (timer + cleanup) | Faible |
+| *Reversibilite* | N/A | Haute (feature flag) | Moyenne | Haute |
+
+**Option A — Status quo** : aucun changement. Les pipelines bloques restent invisibles. L'utilisateur doit verifier manuellement via `/jobs` ou constater l'absence de notification. La dette s'accumule car chaque restart PM2 peut laisser des pipelines orphelins sans remediation. Cout : 0. Risque : pipelines bloques silencieusement, perte de confiance dans le systeme autonome.
+
+**Option B — Watchdog heartbeat** : le heartbeat (toutes les 10 min) lit `pipelines.json` directement, detecte les steps `running` depuis plus de N minutes (30 min pour agents, 24h pour `discuss`), et declenche une remediation graduee : (1) notification Telegram, (2) passage du step a `failed` dans pipelines.json, (3) creation d'une tache backlog si remediation echoue. Gate par un nouveau champ `lastPipelineWatchdogAt` dans HeartbeatState et feature flag `sdd_pipeline_watchdog`. Estimation : 50-80 LOC dans heartbeat.ts + 10 LOC dans heartbeat-prompt.ts. Avantage principal : le heartbeat est deja un processus de surveillance isole, c'est son role naturel. Pas de nouveau processus PM2.
+
+**Option C — Watchdog in-process (relay)** : ajouter un `setInterval()` dans le relay (claude-relay PM2) qui scanne periodiquement les pipelines. Avantage : acces direct a la Map in-memory de pipeline-tracker, pas besoin de lire le fichier. Inconvenient : le relay est le processus qui peut crasher et causer les orphelins — le watchdog crasherait avec lui. De plus, le relay a deja beaucoup de responsabilites. Le heartbeat est specifiquement concu pour la surveillance externe.
+
+**Option D — Recovery au restart uniquement** : au demarrage du relay, scanner pipelines.json et marquer comme `failed` tous les steps `running` (meme logique que job-manager pour jobs.json). Couvre le cas post-restart mais pas les timeouts en cours d'execution. Solution partielle qui ne detecte pas les agents qui tournent indefiniment sans terminer.
+
+## Section 5 — Verdict et justification
+
+**Verdict : GO**
+
+L'option B (watchdog heartbeat) est clairement la meilleure approche :
+
+1. **Fit architectural** : le heartbeat est concu exactement pour ce type de surveillance. Il tourne deja en processus isole (PM2 cron), lit deja des fichiers JSON (heartbeat-state.json, mcp-pending-notifications.json), et dispose du pattern de gate temporelle (`last*At`) et de cooldowns pour eviter les faux positifs. Ajouter la surveillance de pipelines.json est une extension naturelle de ses responsabilites.
+
+2. **Faible complexite, haute valeur** : 50-80 LOC dans heartbeat.ts (une nouvelle fonction `checkSddPipelines()` calquee sur le pattern existant de `checkStuckTasks()`), 10 LOC dans heartbeat-prompt.ts (nouveau champ HeartbeatState), et un feature flag pour le rollback. Le ratio cout/benefice est excellent.
+
+3. **Complementarite avec l'existant** : l'auto-avancement (`sdd-auto-advance.ts`) gere le happy-path, le watchdog gere les cas d'echec. Les deux mecanismes ne se chevauchent pas. L'option D (recovery au restart) pourrait etre ajoutee en complement mais ne suffit pas seule.
+
+4. **Sources externes concordantes** : le pattern heartbeat (Fowler) et le pattern de detection d'orphelins (AlgoMaster) confirment que la surveillance periodique avec seuil temporel est l'approche standard pour ce type de probleme. Le seuil de 30 min (3x l'intervalle de 10 min) suit la recommandation de Fowler.
+
+5. **Risque maitrise** : lecture seule de pipelines.json (pas de modification cross-processus risquee), notification via le canal existant (enqueue), et feature flag pour desactiver en cas de probleme.
+
+## Section 6 — Input pour etape suivante
+
+### Option recommandee : B — Watchdog heartbeat
+
+### Fichiers concernes
+
+- `src/heartbeat.ts` : ajouter `checkSddPipelines()` dans la section "Periodic tasks", gate par `lastPipelineWatchdogAt` (toutes les 10 min = chaque pulse)
+- `src/heartbeat-prompt.ts` : ajouter `lastPipelineWatchdogAt: string | null` dans HeartbeatState et `createDefaultState()`
+- `src/feature-flags.ts` : nouveau flag `sdd_pipeline_watchdog` (off par defaut)
+- Tests : `tests/unit/heartbeat-sdd-watchdog.test.ts`
+
+### Contraintes identifiees
+
+1. **Seuils differencies par phase** : les phases agent (explore, spec, challenge, implement, review, doc) ont un seuil de 30-60 min. La phase `discuss` (conversationnelle) a un seuil beaucoup plus long (24h) ou est exclue du watchdog.
+2. **Lecture fichier cross-processus** : le heartbeat et le relay sont des processus PM2 differents. La lecture de `pipelines.json` doit etre tolerante aux fichiers partiellement ecrits (atomic write via tmp+rename est deja en place dans pipeline-tracker).
+3. **Idempotence** : utiliser le systeme de cooldowns existant du heartbeat pour ne pas re-notifier le meme pipeline bloque a chaque pulse.
+4. **Pas de modification de pipelines.json par le heartbeat** : le heartbeat detecte et notifie, mais ne modifie pas pipelines.json (risque de conflit d'ecriture avec le relay). La remediation "marquer comme failed" est optionnelle (Phase 2).
+5. **Remediation graduee** : Notification Telegram (toujours) -> creation tache backlog (si pipeline bloque depuis >2h, optionnel).
+
+### Questions ouvertes a resoudre pendant la spec
+
+1. Le heartbeat doit-il modifier pipelines.json pour marquer les steps comme `failed`, ou seulement notifier ? (risque de conflit d'ecriture cross-processus vs. necessite de nettoyer l'etat)
+2. Faut-il ajouter l'option D (recovery au restart) en complement, dans le relay au demarrage ?
+3. Le seuil de 30 min est-il suffisant pour la phase `implement` qui peut legitimement prendre 1-2h ?
+4. Faut-il lire aussi `jobs.json` en complement de `pipelines.json` pour croiser les donnees (job failed + step still running = orphelin certain) ?

--- a/docs/reviews/implement-contexte-agent-enrichi-s40.md
+++ b/docs/reviews/implement-contexte-agent-enrichi-s40.md
@@ -1,0 +1,63 @@
+# Implementation Report: Contexte Agent Enrichi S40
+
+## Summary
+
+Created `src/agent-context.ts` module and integrated it into `src/sdd-agents.ts` to inject dynamic Supabase data (memory, sprint, tasks, agent memories) into SDD agent prompts.
+
+## Tests Generated
+
+**File:** `tests/unit/agent-context.test.ts` (25 tests)
+
+| V-Criterion | Tests | Description |
+|-------------|-------|-------------|
+| V1 | 1 | buildAgentContext returns non-empty string with context data |
+| V2 | 4 | Parallel fetching via Promise.all (memory, sprint, tasks, agent memories) |
+| V3 | 2 | Timeout enforcement with graceful fallback (partial/empty context) |
+| V4 | 1 | Returns "" when supabase is null |
+| V5 | 1 | Context capped at ~6000 chars (~1500 tokens) |
+| V6 | 1 | Role-specific agent memories included |
+| V7 | 4 | Phase-based data selection (different data per phase) |
+| V8 | 3 | Injectable hooks for testing |
+| V9 | 1 | Feature flag gating (agent_context_injection) |
+| Edge cases | 7 | Null sprint, empty backlog, empty memories, fetch errors, unknown phase/role |
+
+## Files Modified
+
+| File | Changes | LOC |
+|------|---------|-----|
+| `src/agent-context.ts` | **NEW** — Module with buildAgentContext(), injectable hooks, timeout-guarded parallel fetching, compact formatting | 318 |
+| `src/sdd-agents.ts` | Added import, setBuildAgentContextHook, getAgentContext wrapper, appendAgentContext helper. Each runSdd* now calls getAgentContext and injects via appendAgentContext | 637 (+57) |
+| `src/commands/sdd-flow.ts` | Pass `bctx.supabase` as 4th arg to runSddExplore | +1 |
+| `src/commands/exploration.ts` | Pass `bctx.supabase` as 4th arg to runSddExplore (2 call sites) | +2 |
+| `config/features.json` | Added `agent_context_injection: false` feature flag | +1 |
+| `CLAUDE.md` | Documented agent-context.ts and heartbeat-sdd-watchdog.ts modules | +2 |
+| `tests/unit/agent-context.test.ts` | **NEW** — 25 unit tests | 342 |
+
+## Architecture Decisions
+
+1. **Option B (Injection prompt)** — as recommended by exploration. Module fetches data via existing functions and formats a compact text block for system prompt injection.
+
+2. **Feature flag gated** — `agent_context_injection` defaults to `false`. Can be enabled at runtime via Supabase or `/feature enable agent_context_injection`.
+
+3. **Injectable hooks pattern** — consistent with existing sdd-agents.ts patterns (setWriteFileHook, setSpawnSyncHook, etc.) for clean test isolation.
+
+4. **Independent timeouts** — each Supabase fetch has its own timeout (default 3s) via `Promise.race`. Partial results returned on timeout (V3).
+
+5. **Phase-based data selection** — not all phases need all data (V7):
+   - `explore`: memory + tasks + agent memories (no sprint)
+   - `spec/challenge/review/doc`: all 4 data sources
+   - `implement`: sprint + tasks + agent memories (no memory context)
+
+6. **runSddExplore backward-compatible** — 4th `supabase` parameter is optional, defaults to null (returns "" context). Callers with `bctx` access updated.
+
+## Test Results
+
+```
+bun test tests/unit/ — 2150 pass, 0 fail (75 files, 14.93s)
+bun test tests/unit/agent-context.test.ts — 25 pass, 0 fail
+bun test tests/unit/sdd-agents.test.ts — 46 pass, 0 fail
+bun test tests/unit/coding-standards.test.ts — 268 pass, 0 fail
+bun test tests/unit/doc-freshness.test.ts — 4 pass, 0 fail
+```
+
+## Status: DONE

--- a/docs/reviews/implement-orphan-recovery-pont-heartbeat-sdd.md
+++ b/docs/reviews/implement-orphan-recovery-pont-heartbeat-sdd.md
@@ -1,0 +1,71 @@
+---
+phase: 1-implement
+generated_at: "2026-03-26T11:42:00Z"
+subject: "Orphan recovery — pont heartbeat-SDD pour detection et remediation des pipelines bloques"
+status: DONE
+---
+
+# Implementation Report — Orphan Recovery (Heartbeat-SDD Watchdog)
+
+## Tests generes
+
+| Fichier | V-criteres couverts | Tests |
+|---------|-------------------|-------|
+| `tests/unit/heartbeat-sdd-watchdog.test.ts` | V1-V9 | 21 tests |
+
+### V-criteres couverts
+
+- **V1**: Detection des phases agent bloquees (>30 min running) — 3 tests
+- **V2**: Seuil differencie pour phase `discuss` (24h) — 2 tests
+- **V3**: Ignore les phases non-running (pending, ok, failed) — 3 tests
+- **V4**: Phase `running` sans `startedAt` traitee comme bloquee (conservateur) — 1 test
+- **V5**: Degradation gracieuse (fichier absent, JSON malformed, tableau vide) — 3 tests
+- **V6**: Filtrage TTL (pipelines expires >7 jours ignores) — 1 test
+- **V7**: Format des notifications (nom pipeline, phase, temps ecoule) — 2 tests
+- **V8**: Seuil differencie pour phase `implement` (60 min vs 30 min) — 3 tests
+- **V9**: Export `getStuckThresholdMs()` avec valeurs attendues par phase — 3 tests
+
+## Fichiers modifies
+
+| Fichier | Changement | LOC |
+|---------|-----------|-----|
+| `src/heartbeat-sdd-watchdog.ts` | **Nouveau** — module watchdog (detection orphelins SDD) | 140 |
+| `src/heartbeat-prompt.ts` | Ajout `lastPipelineWatchdogAt` dans HeartbeatState + createDefaultState | +2 |
+| `src/heartbeat.ts` | Import watchdog + integration dans periodic tasks (feature-gated) | +28 |
+| `config/features.json` | Nouveau flag `sdd_pipeline_watchdog: true` | +1 |
+| `tests/unit/heartbeat.test.ts` | Fix baseState pour compatibilite avec nouveau champ HeartbeatState | +2/-6 |
+| `tests/unit/heartbeat-sdd-watchdog.test.ts` | **Nouveau** — 21 tests unitaires | 404 |
+
+## Architecture
+
+Option B de l'exploration (watchdog heartbeat) implementee fidellement :
+
+1. **`src/heartbeat-sdd-watchdog.ts`** (140 LOC) : module autonome qui lit `pipelines.json` directement (cross-processus, lecture seule). Exporte `checkSddPipelines(relayDir)` et `getStuckThresholdMs(phase)`.
+
+2. **Seuils differencies par phase** :
+   - Phases agent (explore, spec, challenge, review, doc) : **30 min**
+   - Phase implement : **60 min** (legitimement plus longue)
+   - Phase discuss : **24h** (conversationnelle, pilotee par l'utilisateur)
+   - Phase running sans `startedAt` : traitee comme bloquee (conservateur)
+
+3. **Integration dans heartbeat.ts** : appelee a chaque pulse (10 min), gatee par feature flag `sdd_pipeline_watchdog`. Utilise le systeme de cooldowns existant du heartbeat pour l'idempotence (pas de re-notification pour le meme pipeline bloque).
+
+4. **Notifications** : via `writeMcpPending()` (canal existant du heartbeat) avec prefixe `[SDD Watchdog]`.
+
+## Resultat bun test
+
+```
+2357 pass, 1 skip, 2 fail (pre-existants)
+4797 expect() calls
+84 files
+```
+
+Les 2 echecs sont pre-existants (biome lint sur `sdd-agents.ts`/`agent-context.ts` + ENOENT bun binary dans agent test). Zero regression introduite.
+
+## Statut final
+
+**DONE**
+
+## Prochaine etape
+
+`/dev-review` puis `/dev-doc`

--- a/src/agent-context.ts
+++ b/src/agent-context.ts
@@ -1,0 +1,328 @@
+/**
+ * @module agent-context
+ * @description Builds enriched context from Supabase data for injection into SDD agent prompts.
+ * Fetches memory, sprint, tasks, and agent-specific memories in parallel with timeout.
+ * Format: compact text block <1500 tokens (~6000 chars) injected via --append-system-prompt.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { isFeatureEnabled as _isFeatureEnabledDefault } from "./feature-flags.ts";
+import { createLogger } from "./logger.ts";
+import {
+  getAgentMemories as _getAgentMemoriesDefault,
+  type AgentMemoryRecord,
+} from "./memory/agent-memory.ts";
+import { getMemoryContext as _getMemoryContextDefault } from "./memory/core.ts";
+import {
+  getBacklog as _getBacklogDefault,
+  getCurrentSprint as _getCurrentSprintDefault,
+  getSprintSummary as _getSprintSummaryDefault,
+  type Task,
+} from "./tasks.ts";
+
+const log = createLogger("agent-context");
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Maximum output size in characters (~1500 tokens) */
+const MAX_CONTEXT_CHARS = 6000;
+
+/** Default timeout per fetch in milliseconds */
+const DEFAULT_TIMEOUT_MS = 3000;
+
+/** Max tasks to include in context */
+const MAX_TASKS_IN_CONTEXT = 8;
+
+/** Max agent memories to request */
+const MAX_AGENT_MEMORIES = 5;
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface AgentContextOptions {
+  /** Timeout per fetch in milliseconds (default: 3000) */
+  timeoutMs?: number;
+}
+
+/** Phases that need sprint data */
+const PHASES_WITH_SPRINT = new Set(["spec", "implement", "review", "challenge", "doc"]);
+
+/** Phases that need task data */
+const PHASES_WITH_TASKS = new Set(["explore", "spec", "implement", "review", "challenge", "doc"]);
+
+/** Phases that need memory data */
+const PHASES_WITH_MEMORY = new Set(["explore", "spec", "review", "challenge", "doc"]);
+
+// ── Injectable Hooks (for testing) ──────────────────────────
+
+type MemoryContextHook = (supabase: SupabaseClient) => Promise<string>;
+type CurrentSprintHook = (supabase: SupabaseClient) => Promise<string | null>;
+type SprintSummaryHook = (
+  supabase: SupabaseClient,
+  sprint: string,
+) => Promise<{ total: number; backlog: number; in_progress: number; review: number; done: number }>;
+type BacklogHook = (
+  supabase: SupabaseClient,
+  opts?: { sprint?: string; status?: string },
+) => Promise<Task[]>;
+type AgentMemoriesHook = (
+  supabase: SupabaseClient | null,
+  role: string,
+  limit?: number,
+) => Promise<AgentMemoryRecord[]>;
+type FeatureCheckHook = (flag: string) => boolean;
+
+let _memoryContextHook: MemoryContextHook | undefined;
+let _currentSprintHook: CurrentSprintHook | undefined;
+let _sprintSummaryHook: SprintSummaryHook | undefined;
+let _backlogHook: BacklogHook | undefined;
+let _agentMemoriesHook: AgentMemoriesHook | undefined;
+let _featureCheckHook: FeatureCheckHook | undefined;
+
+/** @internal — for tests only */
+export function setMemoryContextHook(fn: MemoryContextHook | undefined): void {
+  _memoryContextHook = fn;
+}
+
+/** @internal — for tests only */
+export function setCurrentSprintHook(fn: CurrentSprintHook | undefined): void {
+  _currentSprintHook = fn;
+}
+
+/** @internal — for tests only */
+export function setSprintSummaryHook(fn: SprintSummaryHook | undefined): void {
+  _sprintSummaryHook = fn;
+}
+
+/** @internal — for tests only */
+export function setBacklogHook(fn: BacklogHook | undefined): void {
+  _backlogHook = fn;
+}
+
+/** @internal — for tests only */
+export function setAgentMemoriesHook(fn: AgentMemoriesHook | undefined): void {
+  _agentMemoriesHook = fn;
+}
+
+/** @internal — for tests only */
+export function setFeatureCheckHook(fn: FeatureCheckHook | undefined): void {
+  _featureCheckHook = fn;
+}
+
+// ── Internal wrappers ───────────────────────────────────────
+
+function getMemoryContext(supabase: SupabaseClient): Promise<string> {
+  if (_memoryContextHook) return _memoryContextHook(supabase);
+  return _getMemoryContextDefault(supabase);
+}
+
+function getCurrentSprint(supabase: SupabaseClient): Promise<string | null> {
+  if (_currentSprintHook) return _currentSprintHook(supabase);
+  return _getCurrentSprintDefault(supabase);
+}
+
+function getSprintSummary(
+  supabase: SupabaseClient,
+  sprint: string,
+): Promise<{ total: number; backlog: number; in_progress: number; review: number; done: number }> {
+  if (_sprintSummaryHook) return _sprintSummaryHook(supabase, sprint);
+  return _getSprintSummaryDefault(supabase, sprint);
+}
+
+function getBacklog(
+  supabase: SupabaseClient,
+  opts?: { sprint?: string; status?: string },
+): Promise<Task[]> {
+  if (_backlogHook) return _backlogHook(supabase, opts);
+  return _getBacklogDefault(supabase, opts);
+}
+
+function getAgentMemories(
+  supabase: SupabaseClient | null,
+  role: string,
+  limit?: number,
+): Promise<AgentMemoryRecord[]> {
+  if (_agentMemoriesHook) return _agentMemoriesHook(supabase, role, limit);
+  return _getAgentMemoriesDefault(supabase, role, limit);
+}
+
+function checkFeatureEnabled(flag: string): boolean {
+  if (_featureCheckHook) return _featureCheckHook(flag);
+  return _isFeatureEnabledDefault(flag);
+}
+
+// ── Timeout helper ──────────────────────────────────────────
+
+/**
+ * Race a promise against a timeout. Returns fallback value on timeout.
+ */
+function withTimeout<T>(promise: Promise<T>, fallback: T, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise.catch((err) => {
+      log.warn("Fetch error in agent context", { error: String(err) });
+      return fallback;
+    }),
+    new Promise<T>((resolve) => {
+      timer = setTimeout(() => resolve(fallback), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+// ── Formatting helpers ──────────────────────────────────────
+
+function formatMemorySection(memoryContext: string): string {
+  if (!memoryContext) return "";
+  // Truncate if too long (keep first 1500 chars of memory)
+  const truncated =
+    memoryContext.length > 1500 ? memoryContext.substring(0, 1500) + "..." : memoryContext;
+  return `[MEMOIRE]\n${truncated}`;
+}
+
+function formatSprintSection(
+  sprint: string | null,
+  summary: {
+    total: number;
+    backlog: number;
+    in_progress: number;
+    review: number;
+    done: number;
+  } | null,
+): string {
+  if (!sprint) return "";
+  const parts = [`[SPRINT] ${sprint}`];
+  if (summary) {
+    const pct = summary.total > 0 ? Math.round((summary.done / summary.total) * 100) : 0;
+    parts.push(
+      `Total: ${summary.total} | Backlog: ${summary.backlog} | En cours: ${summary.in_progress} | Review: ${summary.review} | Done: ${summary.done} (${pct}%)`,
+    );
+  }
+  return parts.join("\n");
+}
+
+function formatTasksSection(tasks: Task[]): string {
+  if (tasks.length === 0) return "";
+  const lines = tasks.slice(0, MAX_TASKS_IN_CONTEXT).map((t) => {
+    const status =
+      t.status === "in_progress"
+        ? "[>]"
+        : t.status === "review"
+          ? "[?]"
+          : t.status === "done"
+            ? "[x]"
+            : "[ ]";
+    const priority = `P${t.priority}`;
+    return `${status} ${priority} ${t.title}`;
+  });
+  return `[TACHES ACTIVES]\n${lines.join("\n")}`;
+}
+
+function formatAgentMemoriesSection(memories: AgentMemoryRecord[]): string {
+  if (memories.length === 0) return "";
+  const lines = memories.map((m) => `- ${m.content}`);
+  return `[APPRENTISSAGES AGENT]\n${lines.join("\n")}`;
+}
+
+// ── Main function ───────────────────────────────────────────
+
+/**
+ * Build enriched context from Supabase for injection into SDD agent prompts.
+ *
+ * Fetches in parallel: memory context, sprint info, active tasks, agent memories.
+ * Each fetch has an independent timeout (default 3s) with graceful fallback.
+ * Output is a compact text block capped at ~6000 chars (~1500 tokens).
+ *
+ * @param supabase - Supabase client (null returns "")
+ * @param role - Agent role (e.g. "explorer", "spec-architect", "reviewer")
+ * @param phase - SDD pipeline phase (e.g. "explore", "spec", "challenge", "implement", "review")
+ * @param options - Optional configuration (timeoutMs)
+ * @returns Formatted context string, or "" if disabled/unavailable
+ */
+export async function buildAgentContext(
+  supabase: SupabaseClient | null,
+  role: string,
+  phase: string,
+  options?: AgentContextOptions,
+): Promise<string> {
+  // V4: null supabase → empty
+  if (!supabase) return "";
+
+  // V9: feature flag gating
+  if (!checkFeatureEnabled("agent_context_injection")) return "";
+
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  try {
+    // Determine what to fetch based on phase (V7)
+    const needsMemory = PHASES_WITH_MEMORY.has(phase);
+    const needsSprint = PHASES_WITH_SPRINT.has(phase);
+    const needsTasks = PHASES_WITH_TASKS.has(phase);
+
+    // V2: Parallel fetching with independent timeouts (V3)
+    const [memoryContext, sprint, tasks, agentMemories] = await Promise.all([
+      needsMemory ? withTimeout(getMemoryContext(supabase), "", timeoutMs) : Promise.resolve(""),
+      needsSprint
+        ? withTimeout(getCurrentSprint(supabase), null, timeoutMs)
+        : Promise.resolve(null),
+      needsTasks
+        ? withTimeout(
+            getBacklog(supabase, { status: undefined }).then((all) =>
+              all.filter((t) => t.status !== "done" && t.status !== "cancelled"),
+            ),
+            [] as Task[],
+            timeoutMs,
+          )
+        : Promise.resolve([] as Task[]),
+      withTimeout(getAgentMemories(supabase, role, MAX_AGENT_MEMORIES), [], timeoutMs),
+    ]);
+
+    // Fetch sprint summary if we have a sprint
+    let sprintSummary: {
+      total: number;
+      backlog: number;
+      in_progress: number;
+      review: number;
+      done: number;
+    } | null = null;
+    if (sprint && needsSprint) {
+      sprintSummary = await withTimeout(getSprintSummary(supabase, sprint), null, timeoutMs);
+    }
+
+    // Format sections
+    const sections: string[] = [];
+
+    const memSection = formatMemorySection(memoryContext);
+    if (memSection) sections.push(memSection);
+
+    const sprintSection = formatSprintSection(sprint, sprintSummary);
+    if (sprintSection) sections.push(sprintSection);
+
+    const tasksSection = formatTasksSection(tasks);
+    if (tasksSection) sections.push(tasksSection);
+
+    const agentSection = formatAgentMemoriesSection(agentMemories);
+    if (agentSection) sections.push(agentSection);
+
+    // If no data was fetched, return empty
+    if (sections.length === 0) return "";
+
+    // Assemble with header
+    let result = `--- CONTEXTE PROJET ---\n${sections.join("\n\n")}\n---`;
+
+    // V5: Cap total size
+    if (result.length > MAX_CONTEXT_CHARS) {
+      result = result.substring(0, MAX_CONTEXT_CHARS - 3) + "...";
+    }
+
+    log.info("Agent context built", {
+      role,
+      phase,
+      sections: sections.length,
+      chars: result.length,
+    });
+
+    return result;
+  } catch (error) {
+    log.error("buildAgentContext failed", { role, phase, error: String(error) });
+    return "";
+  }
+}

--- a/src/commands/exploration.ts
+++ b/src/commands/exploration.ts
@@ -116,7 +116,7 @@ export default function explorationCommands(bctx: BotContext): Composer<Context>
       const jobId = await launchJob(
         `sdd-explore:${pipelineName}`,
         chatId,
-        () => runSddExplore(pipelineName, chatId, threadId),
+        () => runSddExplore(pipelineName, chatId, threadId, bctx.supabase),
         { messageThreadId: threadId },
       );
 
@@ -129,7 +129,7 @@ export default function explorationCommands(bctx: BotContext): Composer<Context>
     } else {
       await ctx.reply(`Exploration en cours: ${query}`, bctx.threadOpts(ctx));
       try {
-        const result = await runSddExplore(pipelineName, chatId, threadId);
+        const result = await runSddExplore(pipelineName, chatId, threadId, bctx.supabase);
         await updateStep(chatId, threadId, "explore", {
           status: "ok",
           summary: result.substring(0, 200),

--- a/src/commands/sdd-flow.ts
+++ b/src/commands/sdd-flow.ts
@@ -260,7 +260,7 @@ export default function sddFlowComposer(bctx: BotContext): Composer<Context> {
           let agentFn: () => Promise<string>;
 
           if (action === "explore") {
-            agentFn = () => runSddExplore(name, chatId, threadId);
+            agentFn = () => runSddExplore(name, chatId, threadId, bctx.supabase);
           } else if (action === "spec") {
             // Assemble handoff before launch (R9, F-DA-6)
             const recentMsgs = await getRecentMessages(bctx.supabase);

--- a/src/heartbeat-prompt.ts
+++ b/src/heartbeat-prompt.ts
@@ -23,6 +23,7 @@ export interface HeartbeatState {
   lastAuditAt: string | null; // when codebase audit last ran
   lastAuditScore: number | null; // last audit score (for regression detection)
   lastFeedbackLoopAt: string | null; // when feedback loop last ran (hourly)
+  lastPipelineWatchdogAt: string | null; // when SDD pipeline watchdog last ran (every pulse)
 }
 
 export interface HeartbeatAction {
@@ -230,5 +231,6 @@ export function createDefaultState(): HeartbeatState {
     lastAuditAt: null,
     lastAuditScore: null,
     lastFeedbackLoopAt: null,
+    lastPipelineWatchdogAt: null,
   };
 }

--- a/src/heartbeat-sdd-watchdog.ts
+++ b/src/heartbeat-sdd-watchdog.ts
@@ -1,0 +1,140 @@
+/**
+ * @module heartbeat-sdd-watchdog
+ * @description SDD pipeline watchdog for heartbeat: detects orphaned/stuck pipeline phases
+ * by reading pipelines.json directly (cross-process, read-only).
+ *
+ * Thresholds:
+ * - Agent phases (explore, spec, challenge, review, doc): 30 min
+ * - Implementation phase: 60 min (legitimately longer)
+ * - Conversational phase (discuss): 24h
+ * - Running phase without startedAt: treated as stuck (conservative)
+ *
+ * Integrated into heartbeat.ts periodic tasks, gated by feature flag `sdd_pipeline_watchdog`.
+ */
+
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { createLogger } from "./logger.ts";
+import type { PipelineTracker, SddPhase } from "./pipeline-tracker.ts";
+
+const log = createLogger("heartbeat-sdd-watchdog");
+
+// ── Thresholds ──────────────────────────────────────────────
+
+/** 30 min default for agent phases */
+const AGENT_THRESHOLD_MS = 30 * 60 * 1000;
+
+/** 60 min for implement phase (can legitimately take longer) */
+const IMPLEMENT_THRESHOLD_MS = 60 * 60 * 1000;
+
+/** 24h for discuss phase (conversational, user-driven) */
+const DISCUSS_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/** 7 days TTL — match pipeline-tracker.ts */
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Get the stuck threshold for a given SDD phase.
+ * Exported for testing and potential future configuration.
+ */
+export function getStuckThresholdMs(phase: SddPhase): number {
+  switch (phase) {
+    case "discuss":
+      return DISCUSS_THRESHOLD_MS;
+    case "implement":
+      return IMPLEMENT_THRESHOLD_MS;
+    default:
+      return AGENT_THRESHOLD_MS;
+  }
+}
+
+// ── Result type ─────────────────────────────────────────────
+
+export interface WatchdogResult {
+  /** Number of orphaned/stuck pipeline phases detected */
+  orphansDetected: number;
+  /** Human-readable notification messages for each detected orphan */
+  notifications: string[];
+}
+
+// ── Core detection ──────────────────────────────────────────
+
+/**
+ * Check all SDD pipelines for stuck/orphaned phases.
+ * Reads pipelines.json directly from disk (cross-process safe, read-only).
+ *
+ * @param relayDir - Path to the relay directory containing pipelines.json
+ * @returns Detection result with count and notification messages
+ */
+export async function checkSddPipelines(relayDir: string): Promise<WatchdogResult> {
+  const pipelinesFile = join(relayDir, "pipelines.json");
+  const now = Date.now();
+
+  // Read and parse pipelines.json (graceful degradation)
+  let entries: Array<{ key: string; tracker: PipelineTracker }>;
+  try {
+    const content = await readFile(pipelinesFile, "utf-8");
+    entries = JSON.parse(content);
+    if (!Array.isArray(entries)) {
+      return { orphansDetected: 0, notifications: [] };
+    }
+  } catch {
+    // R6: optional IO — degrade gracefully (file missing, malformed, etc.)
+    return { orphansDetected: 0, notifications: [] };
+  }
+
+  const notifications: string[] = [];
+
+  for (const { tracker } of entries) {
+    // TTL check — skip expired pipelines (same 7-day TTL as pipeline-tracker.ts)
+    if (now - new Date(tracker.updatedAt).getTime() >= TTL_MS) {
+      continue;
+    }
+
+    // Check each step for stuck "running" status
+    const phases = Object.keys(tracker.steps) as SddPhase[];
+    for (const phase of phases) {
+      const step = tracker.steps[phase];
+      if (step.status !== "running") continue;
+
+      const threshold = getStuckThresholdMs(phase);
+
+      // If no startedAt, treat as stuck (conservative — data integrity issue)
+      if (!step.startedAt) {
+        const msg = `Pipeline « ${tracker.name} » : phase ${phase} en running sans startedAt — potentiellement orpheline`;
+        notifications.push(msg);
+        log.warn("Stuck pipeline detected (no startedAt)", {
+          pipeline: tracker.name,
+          phase,
+          chatId: tracker.chatId,
+        });
+        continue;
+      }
+
+      const elapsedMs = now - new Date(step.startedAt).getTime();
+      if (elapsedMs > threshold) {
+        const elapsedMin = Math.round(elapsedMs / (60 * 1000));
+        const elapsedDisplay =
+          elapsedMin >= 60
+            ? `${Math.floor(elapsedMin / 60)}h${elapsedMin % 60 > 0 ? `${elapsedMin % 60}m` : ""}`
+            : `${elapsedMin}min`;
+        const thresholdMin = Math.round(threshold / (60 * 1000));
+
+        const msg = `Pipeline « ${tracker.name} » : phase ${phase} bloquee depuis ${elapsedDisplay} (seuil: ${thresholdMin}min)`;
+        notifications.push(msg);
+        log.warn("Stuck pipeline detected", {
+          pipeline: tracker.name,
+          phase,
+          elapsed: elapsedDisplay,
+          threshold: thresholdMin,
+          chatId: tracker.chatId,
+        });
+      }
+    }
+  }
+
+  return {
+    orphansDetected: notifications.length,
+    notifications,
+  };
+}

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -51,6 +51,7 @@ import {
   type HeartbeatDelta,
   type HeartbeatState,
 } from "./heartbeat-prompt.ts";
+import { checkSddPipelines } from "./heartbeat-sdd-watchdog.ts";
 // LLM-Ops periodic check
 import { LLMOPS_CHECK_INTERVAL_MS, runLlmOpsCheck } from "./llm-ops.ts";
 import { createLogger } from "./logger.ts";
@@ -692,6 +693,35 @@ export async function pulse(): Promise<{
     }
   } catch (err) {
     log.error("Feedback loop error", { error: err });
+  }
+
+  // Every pulse (10min): SDD pipeline watchdog (gated on feature flag)
+  try {
+    if (isFeatureEnabled("sdd_pipeline_watchdog")) {
+      log.info("Running SDD pipeline watchdog...");
+      const watchdogResult = await checkSddPipelines(RELAY_DIR);
+      if (watchdogResult.orphansDetected > 0) {
+        log.info(`SDD watchdog: ${watchdogResult.orphansDetected} orphan(s) detected.`);
+        for (const notification of watchdogResult.notifications) {
+          // Use cooldown to avoid re-notifying the same stuck pipeline
+          const topic = `sdd-watchdog:${notification.substring(0, 50)}`;
+          if (state.cooldowns[topic] && state.cooldowns[topic] > now) {
+            log.info(`Cooldown actif pour: ${topic}`);
+            continue;
+          }
+
+          await writeMcpPending({
+            type: "alert",
+            severity: "normal",
+            message: `[SDD Watchdog] ${notification}`,
+          });
+          state.cooldowns[topic] = now + COOLDOWN_MS;
+        }
+      }
+      state.lastPipelineWatchdogAt = timestamp;
+    }
+  } catch (err) {
+    log.error("SDD pipeline watchdog error", { error: err });
   }
 
   // Daily: Lightweight audit (structure + tests)

--- a/src/sdd-agents.ts
+++ b/src/sdd-agents.ts
@@ -5,10 +5,12 @@
  * Imports restricted to agent.ts, conversation-handoff.ts, logger.ts (R13).
  */
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { spawnSync } from "bun";
 import { writeFile as _writeFileDefault, mkdir, readFile } from "fs/promises";
 import { dirname, join } from "path";
 import { spawnClaude } from "./agent.ts";
+import { buildAgentContext as _buildAgentContextDefault } from "./agent-context.ts";
 import type { BotContext } from "./bot-context.ts";
 import { formatHandoffForAgent, type HandoffSummary } from "./conversation-handoff.ts";
 import { isFeatureEnabled as _isFeatureEnabledDefault } from "./feature-flags.ts";
@@ -86,6 +88,45 @@ export function setBuildEnrichedPromptHook(
 function enrichPrompt(role: string, base: string): string {
   if (_buildEnrichedPromptHook) return _buildEnrichedPromptHook(role, base);
   return _buildEnrichedPromptDefault(role, base);
+}
+
+/**
+ * Optional test hook: replace buildAgentContext without importing agent-context in tests.
+ * In production this is undefined and the real buildAgentContext is used.
+ */
+let _buildAgentContextHook:
+  | ((supabase: SupabaseClient | null, role: string, phase: string) => Promise<string>)
+  | undefined;
+
+/** @internal — for tests only */
+export function setBuildAgentContextHook(
+  fn:
+    | ((supabase: SupabaseClient | null, role: string, phase: string) => Promise<string>)
+    | undefined,
+): void {
+  _buildAgentContextHook = fn;
+}
+
+function getAgentContext(
+  supabase: SupabaseClient | null,
+  role: string,
+  phase: string,
+): Promise<string> {
+  if (_buildAgentContextHook) return _buildAgentContextHook(supabase, role, phase);
+  return _buildAgentContextDefault(supabase, role, phase);
+}
+
+/**
+ * Append agent context to a system prompt string.
+ * If agentContext is empty, returns the original systemPrompt unchanged.
+ */
+function appendAgentContext(
+  systemPrompt: string | undefined,
+  agentContext: string,
+): string | undefined {
+  if (!agentContext) return systemPrompt;
+  if (!systemPrompt) return agentContext;
+  return `${systemPrompt}\n\n${agentContext}`;
 }
 
 const PROJECT_ROOT = dirname(dirname(import.meta.path));
@@ -172,9 +213,11 @@ export async function runSddExplore(
   name: string,
   _chatId?: number,
   _threadId?: number | undefined,
+  supabase?: SupabaseClient | null,
 ): Promise<string> {
   try {
     const agentDef = await readAgentFile("explorer.md");
+    const agentContext = await getAgentContext(supabase ?? null, "explorer", "explore");
     const humanName = name.replace(/-/g, " ");
 
     const prompt = [
@@ -194,7 +237,7 @@ export async function runSddExplore(
 
     const result = await spawnClaude({
       prompt,
-      systemPrompt: agentDef || undefined,
+      systemPrompt: appendAgentContext(agentDef || undefined, agentContext),
       model: "claude-sonnet-4-6",
       effort: "medium",
     });
@@ -222,6 +265,7 @@ export async function runSddSpec(
 ): Promise<string> {
   try {
     const agentDef = await readAgentFile("spec-architect.md");
+    const agentContext = await getAgentContext(bctx.supabase, "spec-architect", "spec");
     const formattedHandoff = formatHandoffForAgent(handoff);
     const humanName = name.replace(/-/g, " ");
 
@@ -244,7 +288,7 @@ export async function runSddSpec(
 
     const result = await spawnClaude({
       prompt,
-      systemPrompt: agentDef || undefined,
+      systemPrompt: appendAgentContext(agentDef || undefined, agentContext),
       model: "claude-sonnet-4-6",
       effort: "high",
     });
@@ -272,6 +316,8 @@ export async function runSddChallenge(name: string, bctx: BotContext): Promise<s
   try {
     const specPath = `docs/specs/SPEC-${name}.md`;
     const reportPath = join(PROJECT_ROOT, "docs", "reviews", `adversarial-SPEC-${name}.md`);
+    // Fetch context once, shared by all 3 challenge agents
+    const agentContext = await getAgentContext(bctx.supabase, "spec-architect", "challenge");
 
     const agents = [
       { file: "devils-advocate.md", label: "Devil's Advocate" },
@@ -294,7 +340,7 @@ export async function runSddChallenge(name: string, bctx: BotContext): Promise<s
       const agentDef = await readAgentFile(agent.file);
       return spawnClaude({
         prompt: basePrompt,
-        systemPrompt: agentDef || undefined,
+        systemPrompt: appendAgentContext(agentDef || undefined, agentContext),
         model: "claude-sonnet-4-6",
         effort: "medium",
       });
@@ -373,6 +419,7 @@ export async function runSddChallenge(name: string, bctx: BotContext): Promise<s
 /** Run the SDD Implement phase (R8). useWorktree: true, spec + adversarial refs. */
 export async function runSddImplement(name: string, bctx: BotContext): Promise<string> {
   try {
+    const agentContext = await getAgentContext(bctx.supabase, "implementer", "implement");
     const specRef = `docs/specs/SPEC-${name}.md`;
     const adversarialRef = `docs/reviews/adversarial-SPEC-${name}.md`;
 
@@ -392,6 +439,7 @@ export async function runSddImplement(name: string, bctx: BotContext): Promise<s
 
     const result = await spawnClaude({
       prompt,
+      systemPrompt: agentContext || undefined,
       model: "claude-sonnet-4-6",
       effort: "high",
       useWorktree: true,
@@ -429,6 +477,7 @@ export async function runSddDoc(name: string, bctx: BotContext): Promise<string>
     } catch {
       log.warn("dev-doc SKILL.md not found, running without system prompt");
     }
+    const agentContext = await getAgentContext(bctx.supabase, "spec-architect", "doc");
 
     const implRef = `docs/reviews/implement-${name}.md`;
 
@@ -446,7 +495,7 @@ export async function runSddDoc(name: string, bctx: BotContext): Promise<string>
 
     const result = await spawnClaude({
       prompt,
-      systemPrompt: skillContent || undefined,
+      systemPrompt: appendAgentContext(skillContent || undefined, agentContext),
       model: "claude-sonnet-4-6",
       effort: "medium",
     });
@@ -473,6 +522,7 @@ export async function runSddReview(
 ): Promise<string> {
   try {
     const agentDef = await readAgentFile("reviewer.md");
+    const agentContext = await getAgentContext(bctx.supabase, "reviewer", "review");
     const specRef = `docs/specs/SPEC-${name}.md`;
     const implRef = `docs/reviews/implement-${name}.md`;
 
@@ -495,7 +545,7 @@ export async function runSddReview(
 
     const result = await spawnClaude({
       prompt,
-      systemPrompt: agentDef || undefined,
+      systemPrompt: appendAgentContext(agentDef || undefined, agentContext),
       model: "claude-sonnet-4-6",
       effort: "medium",
     });

--- a/tests/unit/agent-context.test.ts
+++ b/tests/unit/agent-context.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Unit Tests — src/agent-context.ts
+ *
+ * Tests for buildAgentContext: fetches Supabase data (memory, tasks, sprint, agent memories)
+ * and formats a compact context block (<1500 tokens) for injection into SDD agent prompts.
+ *
+ * V-criteria coverage:
+ * V1: buildAgentContext returns a non-empty string with Supabase data
+ * V2: Parallel fetching via Promise.all (all sources fetched)
+ * V3: Timeout enforcement (3s default, returns partial on timeout)
+ * V4: Graceful fallback when supabase is null (returns "")
+ * V5: Context size capped at ~6000 chars (~1500 tokens)
+ * V6: Role-specific agent memories included
+ * V7: Phase-based data selection (different data per phase)
+ * V8: Injectable hooks for testing (no real Supabase calls in tests)
+ * V9: Feature flag gating (agent_context_injection)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+// ── Mock dependencies before importing ────────────────────────
+
+// Mock memory module
+const mockGetMemoryContext = async () => "FACTS:\n- Project uses Bun\nGOALS:\n- Ship v2";
+let _getMemoryContextImpl = mockGetMemoryContext;
+
+// Mock tasks module
+const mockGetCurrentSprint = async () => "S40";
+const mockGetSprintSummary = async () => ({
+  total: 10,
+  backlog: 3,
+  in_progress: 4,
+  review: 1,
+  done: 2,
+});
+const mockGetBacklog = async () => [
+  {
+    id: "task-1",
+    title: "Implement agent context",
+    status: "in_progress",
+    priority: 1,
+    sprint: "S40",
+    tags: [],
+    description: "Add context injection",
+    project: "relay",
+    created_at: "2026-03-26",
+    updated_at: "2026-03-26",
+    estimated_hours: null,
+    actual_hours: null,
+    blocked_by: null,
+    notes: null,
+    completed_at: null,
+    acceptance_criteria: null,
+    dev_notes: null,
+    architecture_ref: null,
+    subtasks: [],
+    project_id: null,
+    sdd_pipeline_name: null,
+  },
+  {
+    id: "task-2",
+    title: "Fix memory leak",
+    status: "backlog",
+    priority: 2,
+    sprint: "S40",
+    tags: [],
+    description: null,
+    project: "relay",
+    created_at: "2026-03-26",
+    updated_at: "2026-03-26",
+    estimated_hours: null,
+    actual_hours: null,
+    blocked_by: null,
+    notes: null,
+    completed_at: null,
+    acceptance_criteria: null,
+    dev_notes: null,
+    architecture_ref: null,
+    subtasks: [],
+    project_id: null,
+    sdd_pipeline_name: null,
+  },
+];
+
+let _getCurrentSprintImpl = mockGetCurrentSprint;
+let _getSprintSummaryImpl = mockGetSprintSummary;
+let _getBacklogImpl = mockGetBacklog;
+
+// Mock agent-memory module
+const mockGetAgentMemories = async () => [
+  {
+    id: "am-1",
+    content: "Always check for null supabase",
+    agent_role: "explorer",
+    tags: ["pattern"],
+    importance_score: 0.8,
+    created_at: "2026-03-25",
+    last_accessed_at: null,
+    access_count: 3,
+    metadata: {},
+  },
+];
+let _getAgentMemoriesImpl = mockGetAgentMemories;
+
+// Now import the module under test
+import {
+  buildAgentContext,
+  setAgentMemoriesHook,
+  setBacklogHook,
+  setCurrentSprintHook,
+  setFeatureCheckHook,
+  setMemoryContextHook,
+  setSprintSummaryHook,
+} from "../../src/agent-context.ts";
+
+// ── Setup / Teardown ─────────────────────────────────────────
+
+let featureCheckResult = true;
+
+beforeEach(() => {
+  featureCheckResult = true;
+  _getMemoryContextImpl = mockGetMemoryContext;
+  _getCurrentSprintImpl = mockGetCurrentSprint;
+  _getSprintSummaryImpl = mockGetSprintSummary;
+  _getBacklogImpl = mockGetBacklog;
+  _getAgentMemoriesImpl = mockGetAgentMemories;
+
+  // Install hooks
+  setMemoryContextHook(async (sb) => _getMemoryContextImpl());
+  setCurrentSprintHook(async (sb) => _getCurrentSprintImpl());
+  setSprintSummaryHook(async (sb, sprint) => _getSprintSummaryImpl());
+  setBacklogHook(async (sb, opts) => _getBacklogImpl());
+  setAgentMemoriesHook(async (sb, role, limit) => _getAgentMemoriesImpl());
+  setFeatureCheckHook((flag) => featureCheckResult);
+});
+
+afterEach(() => {
+  // Reset hooks
+  setMemoryContextHook(undefined);
+  setCurrentSprintHook(undefined);
+  setSprintSummaryHook(undefined);
+  setBacklogHook(undefined);
+  setAgentMemoriesHook(undefined);
+  setFeatureCheckHook(undefined);
+});
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock
+const mockSupabase = {} as any;
+
+// ── V4: Graceful fallback when supabase is null ──────────────
+
+describe("buildAgentContext — null supabase", () => {
+  it("V4: returns empty string when supabase is null", async () => {
+    const result = await buildAgentContext(null, "explorer", "explore");
+    expect(result).toBe("");
+  });
+});
+
+// ── V9: Feature flag gating ─────────────────────────────────
+
+describe("buildAgentContext — feature flag disabled", () => {
+  it("V9: returns empty string when agent_context_injection flag is disabled", async () => {
+    featureCheckResult = false;
+    setFeatureCheckHook((flag) => featureCheckResult);
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result).toBe("");
+  });
+});
+
+// ── V1, V2: Basic fetching and formatting ───────────────────
+
+describe("buildAgentContext — basic operation", () => {
+  it("V1: returns a non-empty string with context data", async () => {
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain("CONTEXTE PROJET");
+  });
+
+  it("V2: includes memory context", async () => {
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result).toContain("Project uses Bun");
+    expect(result).toContain("Ship v2");
+  });
+
+  it("V2: includes sprint summary", async () => {
+    const result = await buildAgentContext(mockSupabase, "spec-architect", "spec");
+    expect(result).toContain("S40");
+    expect(result).toContain("10");
+  });
+
+  it("V2: includes active tasks", async () => {
+    const result = await buildAgentContext(mockSupabase, "spec-architect", "spec");
+    expect(result).toContain("Implement agent context");
+  });
+
+  it("V6: includes role-specific agent memories", async () => {
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result).toContain("Always check for null supabase");
+  });
+});
+
+// ── V7: Phase-based data selection ──────────────────────────
+
+describe("buildAgentContext — phase-based selection", () => {
+  it("V7: explore phase includes memory + tasks but limited sprint details", async () => {
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result).toContain("MEMOIRE");
+    expect(result).toContain("TACHES");
+  });
+
+  it("V7: implement phase includes sprint summary for budget awareness", async () => {
+    const result = await buildAgentContext(mockSupabase, "implementer", "implement");
+    expect(result).toContain("SPRINT");
+  });
+
+  it("V7: review phase includes all context sections", async () => {
+    const result = await buildAgentContext(mockSupabase, "reviewer", "review");
+    expect(result).toContain("MEMOIRE");
+    expect(result).toContain("SPRINT");
+    expect(result).toContain("TACHES");
+  });
+
+  it("V7: challenge phase includes tasks for impact evaluation", async () => {
+    const result = await buildAgentContext(mockSupabase, "spec-architect", "challenge");
+    expect(result).toContain("TACHES");
+  });
+});
+
+// ── V5: Context size cap ────────────────────────────────────
+
+describe("buildAgentContext — size constraints", () => {
+  it("V5: context is capped at ~6000 chars", async () => {
+    // Set up oversized data
+    const longContent = "A".repeat(10000);
+    setMemoryContextHook(async () => longContent);
+    setBacklogHook(async () => {
+      const tasks = [];
+      for (let i = 0; i < 50; i++) {
+        tasks.push({
+          id: `task-${i}`,
+          title: `Very long task title number ${i} with extensive description`,
+          status: "backlog" as const,
+          priority: 3,
+          sprint: "S40",
+          tags: [],
+          description: "Long description ".repeat(20),
+          project: "relay",
+          created_at: "2026-03-26",
+          updated_at: "2026-03-26",
+          estimated_hours: null,
+          actual_hours: null,
+          blocked_by: null,
+          notes: null,
+          completed_at: null,
+          acceptance_criteria: null,
+          dev_notes: null,
+          architecture_ref: null,
+          subtasks: [],
+          project_id: null,
+          sdd_pipeline_name: null,
+        });
+      }
+      return tasks;
+    });
+
+    const result = await buildAgentContext(mockSupabase, "reviewer", "review");
+    expect(result.length).toBeLessThanOrEqual(6000); // MAX_CONTEXT_CHARS cap
+  });
+});
+
+// ── V3: Timeout enforcement ─────────────────────────────────
+
+describe("buildAgentContext — timeout handling", () => {
+  it("V3: returns partial context when one fetch times out", async () => {
+    // Make memory context hang forever
+    setMemoryContextHook(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore", {
+      timeoutMs: 200,
+    });
+
+    // Should still have other sections (sprint, tasks, agent memories)
+    // Memory section should be absent or empty
+    expect(result).not.toContain("MEMOIRE");
+    // But tasks/sprint should be present
+    expect(result).toContain("TACHES");
+  });
+
+  it("V3: returns partial context when all fetches time out", async () => {
+    // Make all fetches hang
+    const neverResolves = () => new Promise<never>(() => {});
+    setMemoryContextHook(neverResolves);
+    setCurrentSprintHook(neverResolves);
+    setBacklogHook(neverResolves);
+    setAgentMemoriesHook(neverResolves);
+
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore", {
+      timeoutMs: 200,
+    });
+
+    // Should return empty or minimal context (just the wrapper, no data)
+    expect(result.length).toBeLessThan(100);
+  });
+});
+
+// ── V8: Injectable hooks ────────────────────────────────────
+
+describe("buildAgentContext — injectable hooks", () => {
+  it("V8: custom memory context hook is used", async () => {
+    setMemoryContextHook(async () => "CUSTOM_MEMORY_CONTEXT");
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result).toContain("CUSTOM_MEMORY_CONTEXT");
+  });
+
+  it("V8: custom backlog hook is used", async () => {
+    setBacklogHook(async () => [
+      {
+        id: "custom-1",
+        title: "Custom task from hook",
+        status: "in_progress" as const,
+        priority: 1,
+        sprint: "S40",
+        tags: [],
+        description: null,
+        project: "relay",
+        created_at: "2026-03-26",
+        updated_at: "2026-03-26",
+        estimated_hours: null,
+        actual_hours: null,
+        blocked_by: null,
+        notes: null,
+        completed_at: null,
+        acceptance_criteria: null,
+        dev_notes: null,
+        architecture_ref: null,
+        subtasks: [],
+        project_id: null,
+        sdd_pipeline_name: null,
+      },
+    ]);
+
+    const result = await buildAgentContext(mockSupabase, "spec-architect", "spec");
+    expect(result).toContain("Custom task from hook");
+  });
+
+  it("V8: custom agent memories hook is used", async () => {
+    setAgentMemoriesHook(async () => [
+      {
+        id: "custom-am",
+        content: "Custom agent memory",
+        agent_role: "explorer",
+        tags: [],
+        importance_score: 0.9,
+        created_at: "2026-03-26",
+        last_accessed_at: null,
+        access_count: 1,
+        metadata: {},
+      },
+    ]);
+
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result).toContain("Custom agent memory");
+  });
+});
+
+// ── Edge cases ──────────────────────────────────────────────
+
+describe("buildAgentContext — edge cases", () => {
+  it("returns context even when sprint is null", async () => {
+    setCurrentSprintHook(async () => null);
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result.length).toBeGreaterThan(0);
+    // Should still have memory and tasks
+    expect(result).toContain("MEMOIRE");
+  });
+
+  it("returns context even when backlog is empty", async () => {
+    setBacklogHook(async () => []);
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("returns context even when agent memories are empty", async () => {
+    setAgentMemoriesHook(async () => []);
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result.length).toBeGreaterThan(0);
+    // Agent memory section should be absent
+    expect(result).not.toContain("APPRENTISSAGES AGENT");
+  });
+
+  it("handles error in one fetch gracefully", async () => {
+    setMemoryContextHook(async () => {
+      throw new Error("Supabase connection failed");
+    });
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    // Should still return other sections
+    expect(result).toContain("TACHES");
+  });
+
+  it("handles unknown phase gracefully", async () => {
+    const result = await buildAgentContext(mockSupabase, "explorer", "unknown-phase");
+    // Should still return some context (uses default data selection)
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("handles unknown role gracefully", async () => {
+    const result = await buildAgentContext(mockSupabase, "unknown-role", "explore");
+    // Should still return context without agent memories section
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Format validation ───────────────────────────────────────
+
+describe("buildAgentContext — format", () => {
+  it("uses structured sections with clear delimiters", async () => {
+    const result = await buildAgentContext(mockSupabase, "explorer", "explore");
+    expect(result).toContain("--- CONTEXTE PROJET ---");
+    expect(result).toContain("---");
+  });
+
+  it("sections are clearly labeled", async () => {
+    const result = await buildAgentContext(mockSupabase, "reviewer", "review");
+    // Check for section headers
+    expect(result).toMatch(/MEMOIRE/);
+    expect(result).toMatch(/SPRINT|TACHES/);
+  });
+});

--- a/tests/unit/heartbeat-sdd-watchdog.test.ts
+++ b/tests/unit/heartbeat-sdd-watchdog.test.ts
@@ -1,0 +1,411 @@
+/**
+ * @file heartbeat-sdd-watchdog.test.ts
+ * @description Unit tests for the SDD pipeline watchdog integrated into heartbeat.
+ * Tests checkSddPipelines() detection of orphan/stuck pipelines, differentiated
+ * thresholds per phase, idempotence via cooldowns, and graceful degradation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import type {
+  PipelineStep,
+  PipelineTracker,
+  SddPhase,
+  StepStatus,
+} from "../../src/pipeline-tracker.ts";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const TEST_DIR = join(import.meta.dir, "..", "..", ".test-watchdog-" + process.pid);
+const TEST_RELAY_DIR = join(TEST_DIR, "relay");
+const TEST_PIPELINES_FILE = join(TEST_RELAY_DIR, "pipelines.json");
+const TEST_MCP_PENDING_FILE = join(TEST_RELAY_DIR, "mcp-pending-notifications.json");
+
+/** Build a minimal PipelineTracker for testing */
+function buildTracker(
+  overrides: Partial<PipelineTracker> & {
+    stepOverrides?: Partial<Record<SddPhase, Partial<PipelineStep>>>;
+  } = {},
+): PipelineTracker {
+  const now = new Date().toISOString();
+  const steps = {} as Record<SddPhase, PipelineStep>;
+  const phases: SddPhase[] = [
+    "explore",
+    "discuss",
+    "spec",
+    "challenge",
+    "implement",
+    "review",
+    "doc",
+  ];
+  for (const phase of phases) {
+    steps[phase] = {
+      phase,
+      status: "pending" as StepStatus,
+      ...(overrides.stepOverrides?.[phase] || {}),
+    };
+  }
+  const { stepOverrides: _, ...rest } = overrides;
+  return {
+    chatId: 12345,
+    name: "test-pipeline",
+    steps,
+    createdAt: now,
+    updatedAt: now,
+    ...rest,
+  };
+}
+
+/** Write pipelines.json in the format pipeline-tracker uses */
+async function writePipelinesFile(
+  trackers: Array<{ key: string; tracker: PipelineTracker }>,
+): Promise<void> {
+  await mkdir(TEST_RELAY_DIR, { recursive: true });
+  await writeFile(TEST_PIPELINES_FILE, JSON.stringify(trackers, null, 2));
+}
+
+// ── Setup / Teardown ─────────────────────────────────────────
+
+beforeEach(async () => {
+  await mkdir(TEST_RELAY_DIR, { recursive: true });
+  // Set env vars for the heartbeat module to use our test dirs
+  process.env.RELAY_DIR = TEST_RELAY_DIR;
+  // Clean MCP pending file
+  try {
+    await rm(TEST_MCP_PENDING_FILE, { force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+afterEach(async () => {
+  delete process.env.RELAY_DIR;
+  try {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+// ── Import the module under test ─────────────────────────────
+
+// Lazy import to ensure env vars are set before module loads
+async function importWatchdog() {
+  // Clear module cache to pick up env changes
+  const mod = await import("../../src/heartbeat-sdd-watchdog.ts");
+  return mod;
+}
+
+// ── V1: checkSddPipelines detects stuck agent phases ─────────
+
+describe("checkSddPipelines", () => {
+  describe("V1: Detects stuck agent phases (>30 min running)", () => {
+    it("should detect a pipeline with 'spec' phase stuck for 45 min", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const fortyFiveMinAgo = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          spec: { phase: "spec", status: "running", startedAt: fortyFiveMinAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(1);
+      expect(result.notifications.length).toBe(1);
+      expect(result.notifications[0]).toContain("spec");
+    });
+
+    it("should not flag a pipeline with 'implement' phase running for only 10 min", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          implement: { phase: "implement", status: "running", startedAt: tenMinAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+      expect(result.notifications.length).toBe(0);
+    });
+
+    it("should detect multiple stuck phases across different pipelines", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const tracker1 = buildTracker({
+        chatId: 111,
+        name: "pipeline-1",
+        stepOverrides: {
+          spec: { phase: "spec", status: "running", startedAt: oneHourAgo },
+        },
+      });
+      const tracker2 = buildTracker({
+        chatId: 222,
+        name: "pipeline-2",
+        stepOverrides: {
+          review: { phase: "review", status: "running", startedAt: oneHourAgo },
+        },
+      });
+      await writePipelinesFile([
+        { key: "111:main", tracker: tracker1 },
+        { key: "222:main", tracker: tracker2 },
+      ]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(2);
+      expect(result.notifications.length).toBe(2);
+    });
+  });
+
+  describe("V2: Differentiated threshold for 'discuss' phase (24h)", () => {
+    it("should NOT flag 'discuss' phase running for 2 hours (under 24h threshold)", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          discuss: { phase: "discuss", status: "running", startedAt: twoHoursAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+    });
+
+    it("should flag 'discuss' phase running for 25 hours (over 24h threshold)", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const twentyFiveHoursAgo = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          discuss: { phase: "discuss", status: "running", startedAt: twentyFiveHoursAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(1);
+      expect(result.notifications[0]).toContain("discuss");
+    });
+  });
+
+  describe("V3: Ignores non-running phases", () => {
+    it("should ignore pending phases", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const tracker = buildTracker(); // All phases pending
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+    });
+
+    it("should ignore completed (ok) phases", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const longAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          implement: { phase: "implement", status: "ok", startedAt: longAgo, completedAt: longAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+    });
+
+    it("should ignore failed phases", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const longAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          implement: { phase: "implement", status: "failed", startedAt: longAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+    });
+  });
+
+  describe("V4: Running phase without startedAt", () => {
+    it("should treat running phase without startedAt as stuck (conservative)", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const tracker = buildTracker({
+        stepOverrides: {
+          implement: { phase: "implement", status: "running" },
+          // No startedAt field
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(1);
+    });
+  });
+
+  describe("V5: Graceful degradation - missing pipelines.json", () => {
+    it("should return empty result when pipelines.json does not exist", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      // Don't create the file
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+      expect(result.notifications.length).toBe(0);
+    });
+
+    it("should return empty result when pipelines.json is malformed", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      await mkdir(TEST_RELAY_DIR, { recursive: true });
+      await writeFile(TEST_PIPELINES_FILE, "not valid json{{{");
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+      expect(result.notifications.length).toBe(0);
+    });
+
+    it("should return empty result when pipelines.json is empty array", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      await writePipelinesFile([]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+    });
+  });
+
+  describe("V6: TTL filtering — expired pipelines ignored", () => {
+    it("should ignore pipelines with updatedAt older than 7 days", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        updatedAt: eightDaysAgo,
+        stepOverrides: {
+          implement: { phase: "implement", status: "running", startedAt: eightDaysAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+    });
+  });
+
+  describe("V7: Notification message format", () => {
+    it("should include pipeline name and phase in notification", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        name: "my-feature-pipeline",
+        stepOverrides: {
+          challenge: { phase: "challenge", status: "running", startedAt: oneHourAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.notifications[0]).toContain("my-feature-pipeline");
+      expect(result.notifications[0]).toContain("challenge");
+    });
+
+    it("should include elapsed time in notification", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const ninetyMinAgo = new Date(Date.now() - 90 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          implement: { phase: "implement", status: "running", startedAt: ninetyMinAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      // Should contain some time indication (minutes or hours)
+      expect(result.notifications[0]).toMatch(/\d+/);
+    });
+  });
+
+  describe("V8: Threshold for implement phase (60 min, longer than other agents)", () => {
+    it("should NOT flag 'implement' phase running for 40 min (under 60 min threshold)", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const fortyMinAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          implement: { phase: "implement", status: "running", startedAt: fortyMinAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(0);
+    });
+
+    it("should flag 'implement' phase running for 65 min (over 60 min threshold)", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const sixtyFiveMinAgo = new Date(Date.now() - 65 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          implement: { phase: "implement", status: "running", startedAt: sixtyFiveMinAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(1);
+    });
+
+    it("should flag 'explore' phase running for 35 min (over 30 min threshold)", async () => {
+      const { checkSddPipelines } = await importWatchdog();
+
+      const thirtyFiveMinAgo = new Date(Date.now() - 35 * 60 * 1000).toISOString();
+      const tracker = buildTracker({
+        stepOverrides: {
+          explore: { phase: "explore", status: "running", startedAt: thirtyFiveMinAgo },
+        },
+      });
+      await writePipelinesFile([{ key: "12345:main", tracker }]);
+
+      const result = await checkSddPipelines(TEST_RELAY_DIR);
+      expect(result.orphansDetected).toBe(1);
+    });
+  });
+});
+
+// ── V9: getStuckThresholdMs export ──────────────────────────
+
+describe("getStuckThresholdMs", () => {
+  it("should return 24h for discuss phase", async () => {
+    const { getStuckThresholdMs } = await importWatchdog();
+    expect(getStuckThresholdMs("discuss")).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("should return 60 min for implement phase", async () => {
+    const { getStuckThresholdMs } = await importWatchdog();
+    expect(getStuckThresholdMs("implement")).toBe(60 * 60 * 1000);
+  });
+
+  it("should return 30 min for other agent phases", async () => {
+    const { getStuckThresholdMs } = await importWatchdog();
+    expect(getStuckThresholdMs("explore")).toBe(30 * 60 * 1000);
+    expect(getStuckThresholdMs("spec")).toBe(30 * 60 * 1000);
+    expect(getStuckThresholdMs("challenge")).toBe(30 * 60 * 1000);
+    expect(getStuckThresholdMs("review")).toBe(30 * 60 * 1000);
+    expect(getStuckThresholdMs("doc")).toBe(30 * 60 * 1000);
+  });
+});

--- a/tests/unit/heartbeat.test.ts
+++ b/tests/unit/heartbeat.test.ts
@@ -38,14 +38,12 @@ describe("HeartbeatPrompt", () => {
 
   describe("buildHeartbeatPrompt", () => {
     const baseState: HeartbeatState = {
+      ...createDefaultState(),
       lastPulseAt: "2026-03-17T12:00:00.000Z",
       lastCommitSha: "abc123",
       lastSprintSnapshot: { sprint: "S44", done: 5, total: 10 },
       recentActions: [],
       cooldowns: {},
-      lastAlertCheckAt: null,
-      lastArchivalAt: null,
-      lastAutonomyScanAt: null,
     };
 
     const baseDelta: HeartbeatDelta = {
@@ -394,15 +392,17 @@ describe("Heartbeat Actions", () => {
  * Helper: creates a chainable mock object that resolves any method chain
  * to the given result (used for Supabase query chain mocking).
  */
-function chainResult(result: { data: any; error: any }): any {
+// biome-ignore lint/suspicious/noExplicitAny: Supabase query chain mock requires dynamic typing
+function chainResult(result: { data: unknown; error: unknown }): Record<string, unknown> {
   const handler: ProxyHandler<object> = {
     get(_, prop) {
       if (prop === "then") {
-        return (resolve: (v: any) => any, reject?: (e: any) => any) =>
+        // biome-ignore lint/suspicious/noExplicitAny: Promise callback types
+        return (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
           Promise.resolve(result).then(resolve, reject);
       }
       // Any method call returns a new chainable proxy
-      return (..._args: any[]) => new Proxy({}, handler);
+      return (..._args: unknown[]) => new Proxy({}, handler);
     },
   };
   return new Proxy({}, handler);
@@ -429,6 +429,7 @@ describe("V5: getSprintDelta Supabase error handling", () => {
     };
 
     const lastSnapshot = { sprint: "S44", done: 0, total: 2 };
+    // biome-ignore lint/suspicious/noExplicitAny: mock Supabase client
     const result = await getSprintDelta(supabase as any, lastSnapshot);
 
     expect(result.changed).toBe(false);
@@ -445,6 +446,7 @@ describe("V6: getStaleTasks Supabase error handling", () => {
       from: () => chainResult({ data: null, error: { message: "timeout" } }),
     };
 
+    // biome-ignore lint/suspicious/noExplicitAny: mock Supabase client
     const result = await getStaleTasks(supabase as any);
 
     expect(result.tasks).toBe("");


### PR DESCRIPTION
## Summary
- Nouveau module `agent-context.ts` : fetche en parallèle mémoire, tâches, métriques sprint et agent memories depuis Supabase, injecte dans les prompts des 6 agents SDD (cap 6000 chars, timeout 3-5s, feature flag `agent_context_injection`)
- Nouveau module `heartbeat-sdd-watchdog.ts` : détecte les pipelines SDD bloqués (steps "running" >30min) à chaque tick heartbeat et notifie via mcp-pending-notifications (seuils différenciés par phase, feature flag `sdd_pipeline_watchdog`)
- Corrections biome pré-existantes dans heartbeat.test.ts

## Test plan
- [x] 25 tests agent-context (fetch parallèle, timeout, cap taille, feature flag, phases conditionnelles)
- [x] 21 tests heartbeat-sdd-watchdog (détection, seuils différenciés, dégradation gracieuse, TTL)
- [x] Suite complète : 2359 pass, 0 fail
- [x] Biome + typecheck clean
- [x] Reviews : 92/100 (orphan) + 91/100 (S40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)