### PR TITLE
feat(maturation): proactive contradiction detection in pipeline

### DIFF
--- a/docs/reviews/implement-notification-proactive-decisions-invalidees.md
+++ b/docs/reviews/implement-notification-proactive-decisions-invalidees.md
@@ -1,0 +1,95 @@
+# Rapport d'implémentation : Notification proactive des décisions invalidées
+
+**Pipeline** : notification-proactive-decisions-invalidees
+**Date** : 2026-03-29
+**Branche** : feature/notification-proactive-decisions-invalidees
+**Spec** : SPEC-UNIFIEE (score maturité 8/10, recommandation PROCEED)
+
+---
+
+## Résumé
+
+Implémentation de la détection proactive de contradictions dans le pipeline de maturation. Après chaque phase productive (explore, confront, synthesize, advocate), le pipeline détecte si la sortie de la phase invalide des décisions précédemment validées par l'utilisateur et déclenche un checkpoint interactif si le score de contradiction ≥ 0.85.
+
+---
+
+## Fichiers modifiés
+
+### `src/maturation/types.ts` (+3 LOC)
+- `CheckpointDecision.source` : ajout de `"contradiction"` au type union
+- `MaturationRun` : ajout de `contradictionPauseCount?: number`
+
+### `src/maturation/checkpoint.ts` (+130 LOC)
+Nouvelles exports :
+- `CONTRADICTION_THRESHOLD = 0.85` — seuil de déclenchement (élevé pour éviter les faux positifs)
+- `MAX_CONTRADICTION_PAUSES = 2` — circuit breaker (max 2 pauses contradiction par run)
+- `ContradictionResult` — interface `{ score: number, summary: string }`
+- `buildContradictionDetectorPrompt(phaseOutput, decisions, phaseName)` — prompt pur
+- `parseContradictionResponse(text)` — parser JSON robuste avec validation
+- `detectContradiction(phaseOutput, decisions, callClaude, phaseName)` — détecteur fail-open
+- `startContradictionCheckpoint(run, phaseOutput, phaseName, callClaude)` — orchestrateur avec circuit breaker
+
+Modification :
+- `handleCheckpointResponse` : skip `saveGlobalDecision` si `source === "contradiction"` (décision F-NC-1 : pas de pollution de `decisions.json`)
+
+### `src/commands/maturation.ts` (+35 LOC)
+- `runMaturationPipeline` : ajout de la détection de contradiction après chaque phase éligible (explore, confront, synthesize, advocate) sur `result.status === "ok"` et `result.documents.length > 0`
+- `resumeMaturationAfterCheckpoint` : fix SHOWSTOPPER F-TC-1 — branche explicite `source === "contradiction"` qui préserve `currentPhase` au lieu de sauter à validate
+
+---
+
+## Décisions architecturales respectées
+
+| Décision | Implémentation |
+|----------|---------------|
+| V2 Standard (4 phases) | Détection après explore, confront, synthesize, advocate |
+| Seuil 0.85 | `CONTRADICTION_THRESHOLD = 0.85` |
+| Circuit breaker max 2 | `MAX_CONTRADICTION_PAUSES = 2`, vérification en début de `startContradictionCheckpoint` |
+| Fail-open | `detectContradiction` retourne `null` sur toute erreur Claude |
+| Pas de pollution globale | `handleCheckpointResponse` skip `saveGlobalDecision` pour source=contradiction |
+| F-TC-1 adressé | Branche `source === "contradiction"` dans CONTINUE préserve `currentPhase` |
+
+---
+
+## Tests
+
+**Fichier** : `tests/unit/maturation-contradiction.test.ts`
+**34 tests**, tous verts.
+
+### Suites de tests :
+- `constants` (2) — CONTRADICTION_THRESHOLD=0.85, MAX_CONTRADICTION_PAUSES=2
+- `buildContradictionDetectorPrompt` (5) — nom de phase, décisions, troncature 2000 chars, seuil 0.85, format JSON
+- `parseContradictionResponse` (10) — JSON valide, markdown code block, null sur erreurs (pas de JSON, score non-number, score hors range 0-1, summary manquant, input vide, valeurs limites 0 et 1)
+- `detectContradiction` (7) — null si pas de décisions, null si score < seuil, résultat si score ≥ seuil, exactement au seuil, fail-open sur erreur Claude, fail-open sur réponse invalide, null à 0.84
+- `startContradictionCheckpoint` (6) — null sans décisions, null si score bas, checkpoint source=contradiction, circuit breaker bloque à max, permet max-1, count undefined → 1
+- `handleCheckpointResponse (contradiction)` (4) — pas de saveGlobalDecision, résolution normale, synthesize sauvegarde toujours, advocate sauvegarde toujours
+
+---
+
+## Flux d'exécution
+
+```
+runMaturationPipeline
+  └─ [phase explore/confront/synthesize/advocate] → ok
+      ├─ read phase documents (Bun.file)
+      ├─ startContradictionCheckpoint(run, phaseOutput, phaseName, callClaude)
+      │   ├─ circuit breaker? → null
+      │   ├─ loadGlobalDecisions() → []? → null
+      │   ├─ detectContradiction → score < 0.85? → null
+      │   └─ create CheckpointDecision{source:"contradiction"}, run.contradictionPauseCount++
+      └─ cp? → onProgress(⚠️ Contradiction détectée) → return MATURATION_CHECKPOINT
+
+resumeMaturationAfterCheckpoint (CONTINUE)
+  └─ lastCp.source === "contradiction" → preserve currentPhase (F-TC-1 fix)
+```
+
+---
+
+## Métriques
+
+- LOC ajoutées : ~168 (src) + ~240 (tests)
+- Fichiers sources touchés : 3 (types.ts, checkpoint.ts, maturation.ts)
+- Tests ajoutés : 34
+- Couverture checkpoint.ts : maintenue (fonctions pures testées exhaustivement)
+- TypeScript : 0 erreurs
+- Régression : 0 (2506 tests pass, 0 fail)

--- a/src/commands/maturation.ts
+++ b/src/commands/maturation.ts
@@ -207,6 +207,38 @@ export async function runMaturationPipeline(
 
     await onProgress(buildMaturationStatusBar(run));
 
+    // Contradiction detection: check if phase output invalidates prior decisions
+    const contradictionEligible = ["explore", "confront", "synthesize", "advocate"];
+    if (contradictionEligible.includes(phaseName) && result.documents.length > 0) {
+      let phaseOutput = "";
+      for (const docPath of result.documents) {
+        try {
+          phaseOutput += (await Bun.file(docPath).text()) + "\n\n";
+        } catch {
+          /* ignore read errors */
+        }
+      }
+      if (phaseOutput.trim()) {
+        const { startContradictionCheckpoint, buildCheckpointKeyboard } = await import(
+          "../maturation/checkpoint.ts"
+        );
+        const cp = await startContradictionCheckpoint(
+          run,
+          phaseOutput.trim(),
+          phaseName,
+          bctx.callClaude,
+        );
+        if (cp) {
+          const keyboard = buildCheckpointKeyboard(run.id, cp.options);
+          await onProgress(
+            `\u26A0\uFE0F <b>Contradiction détectée</b> (${escapeHtml(PHASE_LABELS[phaseName])})\n\n${escapeHtml(cp.summary)}`,
+            { parse_mode: "HTML", reply_markup: keyboard },
+          );
+          return `MATURATION_CHECKPOINT:${run.name}:${run.id}`;
+        }
+      }
+    }
+
     // Post-synthesize checkpoint: pause if open questions found
     if (phaseName === "synthesize" && result.status === "ok") {
       const { startCheckpoint, buildCheckpointKeyboard } = await import(
@@ -388,7 +420,10 @@ export async function resumeMaturationAfterCheckpoint(
       const lastCp = run.resolvedCheckpoints[run.resolvedCheckpoints.length - 1];
       if (lastCp.source === "synthesize") {
         run.currentPhase = "advocate";
+      } else if (lastCp.source === "contradiction") {
+        // F-TC-1: preserve currentPhase — contradiction checkpoint does not advance the pipeline
       } else {
+        // "advocate" source → advance to validate
         run.currentPhase = "validate";
       }
     }

--- a/src/maturation/checkpoint.ts
+++ b/src/maturation/checkpoint.ts
@@ -11,11 +11,26 @@ import { join } from "path";
 import { createLogger } from "../logger.ts";
 import { getMaturationDir, listRuns, saveRunMeta } from "./documents.ts";
 import { extractShowstopper } from "./scoring.ts";
-import type { CheckpointDecision, GlobalDecision, MaturationRun } from "./types.ts";
+import type {
+  CheckpointDecision,
+  GlobalDecision,
+  MaturationPhase,
+  MaturationRun,
+} from "./types.ts";
 
 const log = createLogger("maturation/checkpoint");
 
+// ── Constants ─────────────────────────────────────────────────
+
+export const CONTRADICTION_THRESHOLD = 0.85;
+export const MAX_CONTRADICTION_PAUSES = 2;
+
 // ── Public types ─────────────────────────────────────────────
+
+export interface ContradictionResult {
+  score: number;
+  summary: string;
+}
 
 export interface CheckpointAdvice {
   summary: string;
@@ -315,18 +330,20 @@ export async function handleCheckpointResponse(
   run.pendingCheckpoint = undefined;
   run.updatedAt = new Date().toISOString();
 
-  // Save global decision
-  const globalDecision: GlobalDecision = {
-    id: randomUUID(),
-    runId: run.id,
-    runName: run.name,
-    source: checkpoint.source,
-    summary: checkpoint.summary,
-    userChoice,
-    timestamp: new Date().toISOString(),
-    tags: checkpoint.tags,
-  };
-  await saveGlobalDecision(globalDecision);
+  // Save global decision — skipped for contradiction source to avoid polluting decisions.json
+  if (checkpoint.source !== "contradiction") {
+    const globalDecision: GlobalDecision = {
+      id: randomUUID(),
+      runId: run.id,
+      runName: run.name,
+      source: checkpoint.source,
+      summary: checkpoint.summary,
+      userChoice,
+      timestamp: new Date().toISOString(),
+      tags: checkpoint.tags,
+    };
+    await saveGlobalDecision(globalDecision);
+  }
 
   // Save run meta
   await saveRunMeta(run);
@@ -358,6 +375,188 @@ export async function checkMaturationCheckpoint(
     return chatMatch && threadMatch && hasPending;
   });
   return match ?? null;
+}
+
+// ── Contradiction detection ───────────────────────────────────
+
+/**
+ * Builds a prompt asking Claude to evaluate if phase output invalidates existing decisions.
+ */
+export function buildContradictionDetectorPrompt(
+  phaseOutput: string,
+  decisions: GlobalDecision[],
+  phaseName: string,
+): string {
+  const truncatedOutput = phaseOutput.slice(0, 2000);
+  const decisionsText = decisions
+    .slice(0, 10)
+    .map((d, i) => `${i + 1}. [${d.source}] ${d.summary} → Choix: ${d.userChoice}`)
+    .join("\n");
+
+  return `Tu es un détecteur de contradictions pour un pipeline de maturation d'idées logicielles.
+
+## Phase analysée : ${phaseName}
+
+## Sortie de la phase (extrait)
+${truncatedOutput}
+
+## Décisions précédemment validées par l'utilisateur
+${decisionsText}
+
+## Ta mission
+Évalue si la sortie de la phase **invalide ou contredit** des décisions déjà validées par l'utilisateur.
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{
+  "score": 0.0,
+  "summary": "Résumé de la contradiction détectée ou 'Aucune contradiction'"
+}
+
+Règles :
+- score : float entre 0.0 (aucune contradiction) et 1.0 (contradiction forte et claire)
+- Un score >= 0.85 déclenche une alerte à l'utilisateur
+- summary : description concise de la contradiction (ou "Aucune contradiction" si score < 0.85)
+- Ne signale que des contradictions réelles avec les DÉCISIONS VALIDÉES, pas des tensions mineures`;
+}
+
+/**
+ * Parses a ContradictionResult from detector response text.
+ * Returns null on invalid input.
+ */
+export function parseContradictionResponse(text: string): ContradictionResult | null {
+  if (!text || typeof text !== "string") return null;
+
+  let jsonStr: string | null = null;
+
+  const codeBlockMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (codeBlockMatch) {
+    jsonStr = codeBlockMatch[1].trim();
+  }
+
+  if (!jsonStr) {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) jsonStr = jsonMatch[0];
+  }
+
+  if (!jsonStr) {
+    log.warn("parseContradictionResponse: no JSON found");
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch (err) {
+    log.warn("parseContradictionResponse: parse error", { error: String(err) });
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  if (typeof obj.score !== "number" || obj.score < 0 || obj.score > 1) {
+    log.warn("parseContradictionResponse: invalid score", { score: obj.score });
+    return null;
+  }
+
+  if (typeof obj.summary !== "string") {
+    log.warn("parseContradictionResponse: invalid summary");
+    return null;
+  }
+
+  return { score: obj.score, summary: obj.summary };
+}
+
+/**
+ * Detects if phase output contradicts existing decisions.
+ * Returns null when no decisions exist, score is below threshold, or on error (fail-open).
+ */
+export async function detectContradiction(
+  phaseOutput: string,
+  decisions: GlobalDecision[],
+  callClaude: (prompt: string) => Promise<string>,
+  phaseName: string,
+): Promise<ContradictionResult | null> {
+  const effectiveCall = _callClaudeHook ?? callClaude;
+
+  if (decisions.length === 0) return null;
+
+  const prompt = buildContradictionDetectorPrompt(phaseOutput, decisions, phaseName);
+
+  let responseText: string;
+  try {
+    responseText = await effectiveCall(prompt);
+  } catch (err) {
+    log.warn("detectContradiction: callClaude failed (fail-open)", {
+      phaseName,
+      error: String(err),
+    });
+    return null;
+  }
+
+  const result = parseContradictionResponse(responseText);
+  if (!result) return null;
+
+  if (result.score < CONTRADICTION_THRESHOLD) return null;
+
+  return result;
+}
+
+/**
+ * Checks for contradictions between phase output and existing decisions.
+ * Respects circuit breaker (MAX_CONTRADICTION_PAUSES).
+ * Returns null if no contradiction or circuit breaker reached.
+ */
+export async function startContradictionCheckpoint(
+  run: MaturationRun,
+  phaseOutput: string,
+  phaseName: MaturationPhase,
+  callClaude: (prompt: string) => Promise<string>,
+): Promise<CheckpointDecision | null> {
+  const pauseCount = run.contradictionPauseCount ?? 0;
+  if (pauseCount >= MAX_CONTRADICTION_PAUSES) {
+    log.info("startContradictionCheckpoint: circuit breaker reached", {
+      runId: run.id,
+      contradictionPauseCount: pauseCount,
+    });
+    return null;
+  }
+
+  const existingDecisions = await loadGlobalDecisions();
+
+  const contradiction = await detectContradiction(
+    phaseOutput,
+    existingDecisions,
+    callClaude,
+    phaseName,
+  );
+  if (!contradiction) return null;
+
+  const checkpoint: CheckpointDecision = {
+    id: randomUUID(),
+    source: "contradiction",
+    summary: contradiction.summary,
+    options: [
+      "Ignorer cette contradiction et continuer",
+      "Revoir la décision précédente",
+      "Mettre en pause et réévaluer",
+    ],
+    recommendation: "CONTINUE",
+    tags: ["contradiction"],
+  };
+
+  run.pendingCheckpoint = checkpoint;
+  run.contradictionPauseCount = pauseCount + 1;
+  run.updatedAt = new Date().toISOString();
+  await saveRunMeta(run);
+
+  log.info("startContradictionCheckpoint: checkpoint set", {
+    runId: run.id,
+    phaseName,
+    score: contradiction.score,
+  });
+
+  return checkpoint;
 }
 
 // ── Global decisions ──────────────────────────────────────────

--- a/src/maturation/types.ts
+++ b/src/maturation/types.ts
@@ -86,6 +86,7 @@ export interface MaturationRun {
   clarification?: ClarificationState;
   pendingCheckpoint?: CheckpointDecision;
   resolvedCheckpoints?: CheckpointDecision[];
+  contradictionPauseCount?: number;
 }
 
 // Quality gate
@@ -114,7 +115,7 @@ export interface ClarificationState {
 // Checkpoint types
 export interface CheckpointDecision {
   id: string;
-  source: "synthesize" | "advocate";
+  source: "synthesize" | "advocate" | "contradiction";
   summary: string;
   options: string[];
   recommendation: "CONTINUE" | "RE-EXPLORE";

--- a/tests/unit/maturation-contradiction.test.ts
+++ b/tests/unit/maturation-contradiction.test.ts
@@ -1,0 +1,404 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "fs/promises";
+import { join } from "path";
+import {
+  _setCallClaudeHookForTests,
+  buildContradictionDetectorPrompt,
+  CONTRADICTION_THRESHOLD,
+  detectContradiction,
+  handleCheckpointResponse,
+  loadGlobalDecisions,
+  MAX_CONTRADICTION_PAUSES,
+  parseContradictionResponse,
+  saveGlobalDecision,
+  startContradictionCheckpoint,
+} from "../../src/maturation/checkpoint.ts";
+import { _setBaseDirForTests, initRun } from "../../src/maturation/documents.ts";
+import type { GlobalDecision } from "../../src/maturation/types.ts";
+import { createEmptyRun } from "../../src/maturation/types.ts";
+
+const TEST_DIR = join(import.meta.dir, "..", ".test-maturation-contradiction");
+
+function makeDecision(id: string, tags: string[] = []): GlobalDecision {
+  return {
+    id,
+    runId: "run-1",
+    runName: "test-run",
+    source: "synthesize",
+    summary: `Décision ${id}: utiliser PostgreSQL comme base de données`,
+    userChoice: "PostgreSQL",
+    timestamp: new Date().toISOString(),
+    tags,
+  };
+}
+
+describe("maturation/contradiction", () => {
+  beforeEach(async () => {
+    try {
+      await rm(TEST_DIR, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+    await mkdir(TEST_DIR, { recursive: true });
+    _setBaseDirForTests(TEST_DIR);
+    _setCallClaudeHookForTests(undefined);
+  });
+
+  afterEach(async () => {
+    _setBaseDirForTests(undefined);
+    _setCallClaudeHookForTests(undefined);
+    try {
+      await rm(TEST_DIR, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  // ── Constants ────────────────────────────────────────────────
+
+  describe("constants", () => {
+    it("V1: CONTRADICTION_THRESHOLD is 0.85", () => {
+      expect(CONTRADICTION_THRESHOLD).toBe(0.85);
+    });
+
+    it("V2: MAX_CONTRADICTION_PAUSES is 2", () => {
+      expect(MAX_CONTRADICTION_PAUSES).toBe(2);
+    });
+  });
+
+  // ── buildContradictionDetectorPrompt ─────────────────────────
+
+  describe("buildContradictionDetectorPrompt", () => {
+    it("V1: includes phase name in output", () => {
+      const decision = makeDecision("d1");
+      const prompt = buildContradictionDetectorPrompt("phase output text", [decision], "explore");
+      expect(prompt).toContain("explore");
+    });
+
+    it("V2: includes decision summaries and user choices", () => {
+      const decision = makeDecision("d1");
+      const prompt = buildContradictionDetectorPrompt("output", [decision], "confront");
+      expect(prompt).toContain("PostgreSQL");
+      expect(prompt).toContain("Décision d1");
+    });
+
+    it("V3: truncates phase output to 2000 chars", () => {
+      const longOutput = "x".repeat(5000);
+      const decision = makeDecision("d1");
+      const prompt = buildContradictionDetectorPrompt(longOutput, [decision], "advocate");
+      // Total prompt should be reasonable, not 5000+ chars of output
+      expect(prompt.length).toBeLessThan(5000);
+    });
+
+    it("V4: includes 0.85 threshold reference", () => {
+      const decision = makeDecision("d1");
+      const prompt = buildContradictionDetectorPrompt("output", [decision], "synthesize");
+      expect(prompt).toContain("0.85");
+    });
+
+    it("V5: includes score and summary JSON format", () => {
+      const decision = makeDecision("d1");
+      const prompt = buildContradictionDetectorPrompt("output", [decision], "explore");
+      expect(prompt).toContain("score");
+      expect(prompt).toContain("summary");
+    });
+  });
+
+  // ── parseContradictionResponse ───────────────────────────────
+
+  describe("parseContradictionResponse", () => {
+    it("V1: parses valid JSON with score and summary", () => {
+      const text = JSON.stringify({ score: 0.9, summary: "Contradiction with DB choice" });
+      const result = parseContradictionResponse(text);
+      expect(result).not.toBeNull();
+      expect(result!.score).toBe(0.9);
+      expect(result!.summary).toBe("Contradiction with DB choice");
+    });
+
+    it("V2: parses JSON from markdown code block", () => {
+      const text = '```json\n{"score": 0.95, "summary": "Forte contradiction"}\n```';
+      const result = parseContradictionResponse(text);
+      expect(result).not.toBeNull();
+      expect(result!.score).toBe(0.95);
+      expect(result!.summary).toBe("Forte contradiction");
+    });
+
+    it("V3: returns null for plain text (no JSON)", () => {
+      expect(parseContradictionResponse("not json at all")).toBeNull();
+    });
+
+    it("V4: returns null when score is not a number", () => {
+      const text = JSON.stringify({ score: "high", summary: "test" });
+      expect(parseContradictionResponse(text)).toBeNull();
+    });
+
+    it("V5: returns null when score is out of range (> 1)", () => {
+      const text = JSON.stringify({ score: 1.5, summary: "test" });
+      expect(parseContradictionResponse(text)).toBeNull();
+    });
+
+    it("V6: returns null when score is out of range (< 0)", () => {
+      const text = JSON.stringify({ score: -0.1, summary: "test" });
+      expect(parseContradictionResponse(text)).toBeNull();
+    });
+
+    it("V7: returns null when summary is missing", () => {
+      const text = JSON.stringify({ score: 0.9 });
+      expect(parseContradictionResponse(text)).toBeNull();
+    });
+
+    it("V8: returns null for empty input", () => {
+      expect(parseContradictionResponse("")).toBeNull();
+    });
+
+    it("V9: accepts score of exactly 0", () => {
+      const text = JSON.stringify({ score: 0, summary: "Aucune contradiction" });
+      const result = parseContradictionResponse(text);
+      expect(result).not.toBeNull();
+      expect(result!.score).toBe(0);
+    });
+
+    it("V10: accepts score of exactly 1", () => {
+      const text = JSON.stringify({ score: 1, summary: "Contradiction totale" });
+      const result = parseContradictionResponse(text);
+      expect(result).not.toBeNull();
+      expect(result!.score).toBe(1);
+    });
+  });
+
+  // ── detectContradiction ──────────────────────────────────────
+
+  describe("detectContradiction", () => {
+    it("V1: returns null when no existing decisions", async () => {
+      _setCallClaudeHookForTests(async () => JSON.stringify({ score: 0.95, summary: "test" }));
+      const result = await detectContradiction("phase output", [], async () => "", "explore");
+      expect(result).toBeNull();
+    });
+
+    it("V2: returns null when score is below threshold (0.7 < 0.85)", async () => {
+      const decisions = [makeDecision("d1")];
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.7, summary: "Tension mineure" }),
+      );
+      const result = await detectContradiction("output", decisions, async () => "", "confront");
+      expect(result).toBeNull();
+    });
+
+    it("V3: returns result when score meets threshold (0.9 >= 0.85)", async () => {
+      const decisions = [makeDecision("d1")];
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.9, summary: "Contradiction forte avec décision précédente" }),
+      );
+      const result = await detectContradiction("output", decisions, async () => "", "advocate");
+      expect(result).not.toBeNull();
+      expect(result!.score).toBe(0.9);
+      expect(result!.summary).toContain("Contradiction");
+    });
+
+    it("V4: returns result at exact threshold (0.85 = 0.85)", async () => {
+      const decisions = [makeDecision("d1")];
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.85, summary: "Exactement au seuil" }),
+      );
+      const result = await detectContradiction("output", decisions, async () => "", "explore");
+      expect(result).not.toBeNull();
+      expect(result!.score).toBe(0.85);
+    });
+
+    it("V5: fail-open on callClaude error (returns null)", async () => {
+      const decisions = [makeDecision("d1")];
+      _setCallClaudeHookForTests(async () => {
+        throw new Error("Claude API unavailable");
+      });
+      const result = await detectContradiction("output", decisions, async () => "", "confront");
+      expect(result).toBeNull();
+    });
+
+    it("V6: fail-open on invalid response (returns null)", async () => {
+      const decisions = [makeDecision("d1")];
+      _setCallClaudeHookForTests(async () => "invalid response — no json here");
+      const result = await detectContradiction("output", decisions, async () => "", "synthesize");
+      expect(result).toBeNull();
+    });
+
+    it("V7: returns null for score just below threshold (0.84 < 0.85)", async () => {
+      const decisions = [makeDecision("d1")];
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.84, summary: "Quasi-contradiction" }),
+      );
+      const result = await detectContradiction("output", decisions, async () => "", "explore");
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── startContradictionCheckpoint ─────────────────────────────
+
+  describe("startContradictionCheckpoint", () => {
+    it("V1: returns null when no global decisions exist", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      await initRun(run);
+      _setCallClaudeHookForTests(async () => JSON.stringify({ score: 0.95, summary: "test" }));
+      // No decisions in global decisions file
+      const result = await startContradictionCheckpoint(run, "output", "explore", async () => "");
+      expect(result).toBeNull();
+      expect(run.pendingCheckpoint).toBeUndefined();
+    });
+
+    it("V2: returns null when score is below threshold", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      await initRun(run);
+      await saveGlobalDecision(makeDecision("d1"));
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.3, summary: "Pas de contradiction" }),
+      );
+      const result = await startContradictionCheckpoint(run, "output", "explore", async () => "");
+      expect(result).toBeNull();
+      expect(run.pendingCheckpoint).toBeUndefined();
+    });
+
+    it("V3: creates checkpoint with source=contradiction when detected", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      await initRun(run);
+      await saveGlobalDecision(makeDecision("d1"));
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({
+          score: 0.92,
+          summary: "Contradiction avec la décision sur la base de données",
+        }),
+      );
+      const result = await startContradictionCheckpoint(run, "output", "confront", async () => "");
+      expect(result).not.toBeNull();
+      expect(result!.source).toBe("contradiction");
+      expect(result!.summary).toContain("Contradiction");
+      expect(result!.tags).toContain("contradiction");
+      expect(result!.options.length).toBeGreaterThan(0);
+      expect(run.pendingCheckpoint).not.toBeUndefined();
+      expect(run.pendingCheckpoint!.source).toBe("contradiction");
+      expect(run.contradictionPauseCount).toBe(1);
+    });
+
+    it("V4: circuit breaker blocks when contradictionPauseCount >= MAX_CONTRADICTION_PAUSES", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      await initRun(run);
+      run.contradictionPauseCount = MAX_CONTRADICTION_PAUSES; // Already at max
+      await saveGlobalDecision(makeDecision("d1"));
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.99, summary: "Very strong contradiction" }),
+      );
+      const result = await startContradictionCheckpoint(run, "output", "advocate", async () => "");
+      expect(result).toBeNull();
+      // Count should not have increased
+      expect(run.contradictionPauseCount).toBe(MAX_CONTRADICTION_PAUSES);
+    });
+
+    it("V5: allows pause when count is one below max (MAX-1 < MAX)", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      await initRun(run);
+      run.contradictionPauseCount = MAX_CONTRADICTION_PAUSES - 1;
+      await saveGlobalDecision(makeDecision("d1"));
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.9, summary: "Contradiction détectée" }),
+      );
+      const result = await startContradictionCheckpoint(run, "output", "explore", async () => "");
+      expect(result).not.toBeNull();
+      expect(run.contradictionPauseCount).toBe(MAX_CONTRADICTION_PAUSES);
+    });
+
+    it("V6: count defaults to 0 when contradictionPauseCount is undefined", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      await initRun(run);
+      // contradictionPauseCount is undefined by default
+      expect(run.contradictionPauseCount).toBeUndefined();
+      await saveGlobalDecision(makeDecision("d1"));
+      _setCallClaudeHookForTests(async () =>
+        JSON.stringify({ score: 0.9, summary: "Première contradiction" }),
+      );
+      const result = await startContradictionCheckpoint(run, "output", "explore", async () => "");
+      expect(result).not.toBeNull();
+      expect(run.contradictionPauseCount).toBe(1);
+    });
+  });
+
+  // ── handleCheckpointResponse (contradiction source) ──────────
+
+  describe("handleCheckpointResponse (contradiction source)", () => {
+    it("V1: does NOT save to global decisions for source=contradiction", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      run.pendingCheckpoint = {
+        id: "cp-contradiction-1",
+        source: "contradiction",
+        summary: "Contradiction détectée avec décision PostgreSQL",
+        options: ["Ignorer", "Revoir"],
+        recommendation: "CONTINUE",
+        tags: ["contradiction"],
+      };
+      await initRun(run);
+
+      await handleCheckpointResponse(run, "Ignorer cette contradiction et continuer");
+
+      // Verify no global decision was saved
+      const decisions = await loadGlobalDecisions();
+      expect(decisions).toHaveLength(0);
+    });
+
+    it("V2: resolves checkpoint (clears pendingCheckpoint, adds to resolvedCheckpoints)", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      run.pendingCheckpoint = {
+        id: "cp-contradiction-2",
+        source: "contradiction",
+        summary: "Test contradiction",
+        options: ["Option A"],
+        recommendation: "CONTINUE",
+        tags: ["contradiction"],
+      };
+      await initRun(run);
+
+      const result = await handleCheckpointResponse(run, "Option A");
+
+      expect(result.action).toBe("CONTINUE");
+      expect(run.pendingCheckpoint).toBeUndefined();
+      expect(run.resolvedCheckpoints).toHaveLength(1);
+      expect(run.resolvedCheckpoints![0].source).toBe("contradiction");
+      expect(run.resolvedCheckpoints![0].userChoice).toBe("Option A");
+    });
+
+    it("V3: saves to global decisions for source=synthesize (existing behavior unchanged)", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      run.pendingCheckpoint = {
+        id: "cp-synth-1",
+        source: "synthesize",
+        summary: "Choix de base de données",
+        options: ["PostgreSQL", "SQLite"],
+        recommendation: "CONTINUE",
+        tags: ["architecture"],
+      };
+      await initRun(run);
+
+      await handleCheckpointResponse(run, "PostgreSQL");
+
+      const decisions = await loadGlobalDecisions();
+      expect(decisions).toHaveLength(1);
+      expect(decisions[0].source).toBe("synthesize");
+      expect(decisions[0].userChoice).toBe("PostgreSQL");
+    });
+
+    it("V4: saves to global decisions for source=advocate (existing behavior unchanged)", async () => {
+      const run = createEmptyRun(1, undefined, "test", "input");
+      run.pendingCheckpoint = {
+        id: "cp-adv-1",
+        source: "advocate",
+        summary: "Showstopper identifié",
+        options: ["Revoir", "Continuer"],
+        recommendation: "RE-EXPLORE",
+        tags: ["blocage"],
+      };
+      await initRun(run);
+
+      await handleCheckpointResponse(run, "Revoir");
+
+      const decisions = await loadGlobalDecisions();
+      expect(decisions).toHaveLength(1);
+      expect(decisions[0].source).toBe("advocate");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- After each productive phase (explore, confront, synthesize, advocate), detect if phase output **contradicts previously validated decisions** (threshold 0.85)
- Pause pipeline with interactive `contradiction` checkpoint — does NOT pollute `decisions.json`
- Fix **F-TC-1**: `resumeMaturationAfterCheckpoint` CONTINUE branch now preserves `currentPhase` for `source=contradiction` (was incorrectly jumping to validate)
- Circuit breaker: max 2 contradiction pauses per run (`MAX_CONTRADICTION_PAUSES = 2`)
- Fail-open: any detector error → pipeline continues uninterrupted

## Changes

**3 source files, ~168 LOC:**
- `src/maturation/types.ts`: extend `CheckpointDecision.source` with `"contradiction"`, add `contradictionPauseCount?: number` to `MaturationRun`
- `src/maturation/checkpoint.ts`: add `CONTRADICTION_THRESHOLD=0.85`, `MAX_CONTRADICTION_PAUSES=2`, `ContradictionResult`, `buildContradictionDetectorPrompt`, `parseContradictionResponse`, `detectContradiction`, `startContradictionCheckpoint`; modify `handleCheckpointResponse` to skip global decision save for `source=contradiction`
- `src/commands/maturation.ts`: wire contradiction detection after each eligible phase; fix F-TC-1 in `resumeMaturationAfterCheckpoint`

**New test file:** `tests/unit/maturation-contradiction.test.ts` — 34 tests

## Test plan

- [x] `bun test tests/unit tests/integration` — 2506 pass, 0 fail
- [x] TypeScript typecheck — 0 errors
- [x] Biome format + lint — clean
- [x] All 34 new tests green (constants, prompt builder, parser, detector, checkpoint, handleResponse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)